### PR TITLE
Feature/evaluation metrics

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,9 +12,9 @@ jobs:
     build:
         strategy:
           matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest"]  #, "macos-latest"]
             python-version: [ "3.10", "3.11", "3.12" ]
-            mpi: [ "openmpi" ]  # "mpich", "intelmpi"
+            mpi: [ "openmpi" ]  # ,"mpich", "intelmpi"
 #            exclude:
 #              - os: "macos-latest"
 #                mpi: "intelmpi"

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ distributed_random_forest.evaluate(local_test.x, local_test.y, num_classes, glob
 
 ## Evaluation Metrics
 
-To ease the evaluation of large-scale datasets, we implement multi-class evaluation metrics operating directly on the confusion matrix (instead of the true vs predicted values for all samples). 
+To ease the evaluation of large-scale datasets, we implement multi-class evaluation metrics operating directly on the confusion matrix (instead of the true vs predicted values for all samples).
 
 We support the following metrics, with the interfaces based on the corresponding `sklearn.metrics` functions:
 - **Accuracy:** the global accuracy
@@ -132,7 +132,7 @@ We support the following metrics, with the interfaces based on the corresponding
 ```python3
 import numpy as np
 from specialcouscous import evaluation_metrics
- 
+
 path_to_confusion_matrix_csv = "example.csv"
 confusion_matrix = np.loadtxt(path_to_confusion_matrix_csv)
 

--- a/README.md
+++ b/README.md
@@ -116,16 +116,16 @@ distributed_random_forest.evaluate(local_test.x, local_test.y, num_classes, glob
 To ease the evaluation of large-scale datasets, we implement multi-class evaluation metrics operating directly on the confusion matrix (instead of the true vs predicted values for all samples).
 
 We support the following metrics, with the interfaces based on the corresponding `sklearn.metrics` functions:
-- **Accuracy:** the global accuracy
-- **Balanced Accuracy:** the accuracy as average over class-wise recalls
-- **Precision, Recall, and Fβ-Score:** with the following averaging options (`average` parameter)
-  - `None`: no averaging, return class-wise
-  - `"micro"`: compute metrics globally → equal importance on each sample
-  - `"macro"`: compute metrics class-wise, then average over classes → equal importance on each class, minority classes can outweigh majority classes
-  - `"weighted"`: compute metrics class-wise, then average over classes weighted by their support (#true samples)
-  - As we are focussing on multi-class classification, the average options `"binary"` and `"samples"` are not included.
-- **Cohen's Kappa:** compare classification to random guessing, values from -1 to +1, the higher the better, robust to class imbalance but not originally intended for classification problems
-- **Matthews Correlation Coefficient (MCC):** see https://en.wikipedia.org/wiki/Phi_coefficient, values from -1 to +1, the higher the better, robust to class imbalance
+- **Accuracy:** The global accuracy
+- **Balanced Accuracy:** The accuracy as average over class-wise recalls
+- **Precision, Recall, and Fβ-Score:** With the following averaging options (`average` parameter)
+  - `None`: No averaging, return class-wise
+  - `"micro"`: Compute metrics globally → equal importance on each sample
+  - `"macro"`: Compute metrics class-wise, then average over classes → equal importance on each class, minority classes can outweigh majority classes
+  - `"weighted"`: Compute metrics class-wise, then average over classes weighted by their support (#true samples)
+  - As we focus on multi-class classification, the average options `"binary"` and `"samples"` are not included.
+- **Cohen's Kappa:** Compare classification to random guessing, values from -1 to +1, the higher the better, robust to class imbalance but not originally intended for classification problems
+- **Matthews Correlation Coefficient (MCC):** See https://en.wikipedia.org/wiki/Phi_coefficient, values from -1 to +1, the higher the better, robust to class imbalance
 
 ### Usage
 
@@ -139,11 +139,11 @@ confusion_matrix = np.loadtxt(path_to_confusion_matrix_csv)
 accuracy = evaluation_metrics.accuracy_score(confusion_matrix)
 balanced_accuracy = evaluation_metrics.balanced_accuracy_score(confusion_matrix)
 
-# precision_recall_fscore compute all three metrics at once
+# `precision_recall_fscore` computes all three metrics at once.
 for average in [None, "micro", "macro", "weighted"]:
     precision, recall, f_score = evaluation_metrics.precision_recall_fscore(confusion_matrix, beta=1.0, average=average)
 
-# additionally, you can also call each specific metric on their own, but underneath, they just call precision_recall_fscore
+# Additionally, you can also call each specific metric on their own, but underneath, they just call `precision_recall_fscore`.
 precision = evaluation_metrics.precision_score(confusion_matrix, average=None)
 recall = evaluation_metrics.recall_score(confusion_matrix, average=None)
 fbeta = evaluation_metrics.fbeta_score(confusion_matrix, beta=2.0, average=None)

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -202,41 +202,6 @@ def recall_score(
     return recall
 
 
-def _f_score_from_precision_and_recall(
-    precision: float | np.ndarray[float], recall: float | np.ndarray[float], beta: float
-) -> float | np.ndarray[float]:
-    """
-    Compute the F-beta score from precision and recall values. Supports both scalar and array inputs.
-
-    Parameters
-    ----------
-    precision : float | np.ndarray[float]
-        The precision score, either a single value or multiple values in an array (e.g. class-wise). Precision and
-        recall are expected to have the same shape.
-    recall : float | np.ndarray[float]
-        The recall score, either a single value or multiple values in an array (e.g. class-wise). Precision and
-        recall are expected to have the same shape.
-    beta : float
-        The weight of recall in the F score.
-
-    Returns
-    -------
-    float | np.ndarray[float]
-        The f-beta score based on the given precision and recall values. Has the same shape as the input.
-    """
-    nominator = precision * recall
-    denominator = beta**2 * precision + recall
-
-    if isinstance(denominator, np.ndarray):
-        fscore = (1 + beta**2) * nominator / denominator
-        fscore[np.logical_and(denominator == 0, np.isnan(fscore))] = (
-            0  # replace nan from division by zero with zeros
-        )
-        return fscore
-    else:  # scalar case, avoid division by zero for scalar values
-        return 0 if (denominator == 0) else (1 + beta**2) * nominator / denominator
-
-
 def fbeta_score(
     confusion_matrix: np.ndarray, beta: float, average: str | None = None
 ) -> float | np.ndarray[float]:

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -17,7 +17,9 @@ def accuracy_score(confusion_matrix: np.ndarray) -> float:
     float
         The overall accuracy computed for the given confusion matrix.
     """
-    pass
+    n_samples = confusion_matrix.sum()
+    n_correct = confusion_matrix.diagonal().sum()
+    return n_correct / n_samples
 
 
 def balanced_accuracy_score(confusion_matrix: np.ndarray) -> float:
@@ -36,7 +38,8 @@ def balanced_accuracy_score(confusion_matrix: np.ndarray) -> float:
     float
         The balanced accuracy computed for the given confusion matrix.
     """
-    pass
+    # macro average = first compute class-wise recall, then average
+    return recall_score(confusion_matrix, average='macro')
 
 
 def precision_recall_fscore(
@@ -217,7 +220,16 @@ def cohen_kappa_score(confusion_matrix: np.ndarray) -> float:
     float
         Cohen’s kappa computed for the given confusion matrix.
     """
-    pass
+    n_samples = confusion_matrix.sum()
+
+    predicted_samples_per_class = np.sum(confusion_matrix, axis=0)
+    true_samples_per_class = np.sum(confusion_matrix, axis=1)
+    expected_confusion_matrix = np.outer(predicted_samples_per_class, true_samples_per_class) / n_samples
+
+    expected_accuracy = expected_confusion_matrix.diagonal().sum() / n_samples  # = expected agreement p_e
+    observed_accuracy = confusion_matrix.diagonal().sum() / n_samples  # = observed agreement p_o
+
+    return (observed_accuracy - expected_accuracy) / (1 - expected_accuracy)  # = Cohen's kappa (p_o - p_e) / (1 - p_e)
 
 
 def matthews_corrcoef(confusion_matrix: np.ndarray) -> float:

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -39,7 +39,7 @@ def balanced_accuracy_score(confusion_matrix: np.ndarray) -> float:
         The balanced accuracy computed for the given confusion matrix.
     """
     # macro average = first compute class-wise recall, then average
-    return recall_score(confusion_matrix, average='macro')
+    return recall_score(confusion_matrix, average="macro")
 
 
 def precision_recall_fscore(
@@ -126,9 +126,7 @@ def precision_recall_fscore(
     return precision, recall, f_score
 
 
-def precision_score(
-    confusion_matrix: np.ndarray, average: str | None = None
-) -> float | np.ndarray[float]:
+def precision_score(confusion_matrix: np.ndarray, average: str | None = None) -> float | np.ndarray[float]:
     """
     Compute the precision score for the given confusion matrix of a multi-class classification model. The result is
     either returned as class-wise values (if average == None) or averaged.
@@ -154,9 +152,7 @@ def precision_score(
     return precision
 
 
-def recall_score(
-    confusion_matrix: np.ndarray, average: str | None = None
-) -> float | np.ndarray[float]:
+def recall_score(confusion_matrix: np.ndarray, average: str | None = None) -> float | np.ndarray[float]:
     """
     Compute the recall score for the given confusion matrix of a multi-class classification model. The result is either
     returned as class-wise values (if average == None) or averaged.
@@ -209,9 +205,7 @@ def __f_score_from_precision_and_recall(
     return 0 if denominator is 0 else (1 + beta**2) * nominator / denominator
 
 
-def fbeta_score(
-    confusion_matrix: np.ndarray, beta: float, average: str | None = None
-) -> float | np.ndarray[float]:
+def fbeta_score(confusion_matrix: np.ndarray, beta: float, average: str | None = None) -> float | np.ndarray[float]:
     """
     Compute the F-beta score for the given confusion matrix of a multi-class classification model. The result is either
     returned as class-wise values (if average == None) or averaged.
@@ -235,13 +229,11 @@ def fbeta_score(
         The f-beta score either class-wise (if average == None) or averaged over all classes using the specified
         averaging method.
     """
-    _, _, fscore = precision_recall_fscore(confusion_matrix, beta=beta, average=average)
-    return fscore
+    _, _, f_score = precision_recall_fscore(confusion_matrix, beta=beta, average=average)
+    return f_score
 
 
-def f1_score(
-    confusion_matrix: np.ndarray, average: str | None = None
-) -> float | np.ndarray[float]:
+def f1_score(confusion_matrix: np.ndarray, average: str | None = None) -> float | np.ndarray[float]:
     """
     Compute the F1 score for the given confusion matrix of a multi-class classification model. The result is either
     returned as class-wise values (if average == None) or averaged.

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -1,0 +1,239 @@
+import numpy as np
+
+
+def accuracy_score(confusion_matrix: np.ndarray) -> float:
+    """
+    Compute overall accuracy from the given confusion matrix, i.e., #correct predictions / #total samples.
+    Based on sklearn.metrics.accuracy_score but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+
+    Returns
+    -------
+    float
+        The overall accuracy computed for the given confusion matrix.
+    """
+    pass
+
+
+def balanced_accuracy_score(confusion_matrix: np.ndarray) -> float:
+    """
+    Compute the balanced accuracy score as average of the class-wise recalls.
+    Based on sklearn.metrics.balanced_accuracy_score but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+
+    Returns
+    -------
+    float
+        The balanced accuracy computed for the given confusion matrix.
+    """
+    pass
+
+
+def precision_recall_fscore(
+    confusion_matrix: np.ndarray, beta: float = 1.0, average: str | None = None
+) -> tuple[float | np.ndarray[float], float | np.ndarray[float], float | np.ndarray[float]]:
+    """
+    Compute the precision, recall, and f-beta score for the given confusion matrix of a multi-class classification
+    model. The three metrics are either returned as class-wise values (if average == None) or averaged using one of the
+    following methods:
+    - "micro": Metrics are computed globally, i.e. count total true/false positives/negatives for all samples,
+      independent of class. This gives **equal importance to each sample** and should result in
+      precision == recall == f-score == global accuracy.
+    - "macro": Metrics are first computed independently for each class, the class-wise metrics are then averaged over
+      all classes. This gives **equal importance to each class** but minority classes can outweigh majority classes.
+      With balanced classes, "micro" and "macro" should be identical.
+    - "weighted": Metrics are first computed independently for each class (as for macro), the class-wise metrics are
+      then averaged over all classes, each **weighted by their support**. Note that this can result in an F-score that
+      is not between precision and recall.
+    This function is for multi-class but not multi-label classification, thus the average options "binary" and "samples"
+    are not included.
+
+    Based on sklearn.metrics.precision_recall_fscore_support but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+    beta : float
+        The weight of recall in the F score (default: 1.0).
+    average : str | None
+        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
+        the scores are aggregated to a single average score. Available averaging methods are: "micro", "samples",
+        "macro", "weighted", and None for no averaging.
+
+    Returns
+    -------
+    float | np.ndarray[float]
+        The precision score either class-wise (if average == None) or averaged over all classes using the specified
+        averaging method.
+    float | np.ndarray[float]
+        The recall score either class-wise (if average == None) or averaged over all classes using the specified
+        averaging method.
+    float | np.ndarray[float]
+        The f-beta score either class-wise (if average == None) or averaged over all classes using the specified
+        averaging method.
+    """
+    pass
+
+
+def precision_score(
+    confusion_matrix: np.ndarray, average: str | None = None
+) -> float | np.ndarray[float]:
+    """
+    Compute the precision score for the given confusion matrix of a multi-class classification model. The result is
+    either returned as class-wise values (if average == None) or averaged.
+    Based on sklearn.metrics.precision_score but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+    average : str | None
+        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
+        the scores are aggregated to a single average score. See precision_recall_fscore for more details on the
+        available averaging methods.
+
+    Returns
+    -------
+    float | np.ndarray[float]
+        The precision score either class-wise (if average == None) or averaged over all classes using the specified
+        averaging method.
+    """
+    precision, _, _ = precision_recall_fscore(confusion_matrix, average=average)
+    return precision
+
+
+def recall_score(
+    confusion_matrix: np.ndarray, average: str | None = None
+) -> float | np.ndarray[float]:
+    """
+    Compute the recall score for the given confusion matrix of a multi-class classification model. The result is either
+    returned as class-wise values (if average == None) or averaged.
+    Based on sklearn.metrics.recall_score but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+    average : str | None
+        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
+        the scores are aggregated to a single average score. See precision_recall_fscore for more details on the
+        available averaging methods.
+
+    Returns
+    -------
+    float | np.ndarray[float]
+        The recall score either class-wise (if average == None) or averaged over all classes using the specified
+        averaging method.
+    """
+    _, recall, _ = precision_recall_fscore(confusion_matrix, average=average)
+    return recall
+
+
+def fbeta_score(
+    confusion_matrix: np.ndarray, beta: float, average: str | None = None
+) -> float | np.ndarray[float]:
+    """
+    Compute the F-beta score for the given confusion matrix of a multi-class classification model. The result is either
+    returned as class-wise values (if average == None) or averaged.
+    Based on sklearn.metrics.fbeta_score but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+    beta : float
+        The weight of recall in the F score.
+    average : str | None
+        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
+        the scores are aggregated to a single average score. See precision_recall_fscore for more details on the
+        available averaging methods.
+
+    Returns
+    -------
+    float | np.ndarray[float]
+        The f-beta score either class-wise (if average == None) or averaged over all classes using the specified
+        averaging method.
+    """
+    _, _, fscore = precision_recall_fscore(confusion_matrix, beta=beta, average=average)
+    return fscore
+
+
+def f1_score(
+    confusion_matrix: np.ndarray, average: str | None = None
+) -> float | np.ndarray[float]:
+    """
+    Compute the F1 score for the given confusion matrix of a multi-class classification model. The result is either
+    returned as class-wise values (if average == None) or averaged.
+    Based on sklearn.metrics.f1_score but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+    average : str | None
+        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
+        the scores are aggregated to a single average score. See precision_recall_fscore for more details on the
+        available averaging methods.
+
+    Returns
+    -------
+    float | np.ndarray[float]
+        The F1 score either class-wise (if average == None) or averaged over all classes using the specified
+        averaging method.
+    """
+    return fbeta_score(confusion_matrix, beta=1, average=average)
+
+
+def cohen_kappa_score(confusion_matrix: np.ndarray) -> float:
+    """
+    Compute Cohen’s kappa, a measure for agreement between two annotators on a classification problem, for the given
+    confusion matrix.
+    Based on sklearn.metrics.cohen_kappa_score but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+
+    Returns
+    -------
+    float
+        Cohen’s kappa computed for the given confusion matrix.
+    """
+    pass
+
+
+def matthews_corrcoef(confusion_matrix: np.ndarray) -> float:
+    """
+    Compute Matthews correlation coefficient (MCC) for the given confusion matrix.
+    Based on sklearn.metrics.matthews_corrcoef but computed from the confusion matrix instead of using the
+    sample-wise labels and predictions.
+
+    Parameters
+    ----------
+    confusion_matrix : np.ndarray
+        The multi-class classification confusion matrix (non-normalized).
+
+    Returns
+    -------
+    float
+        The Matthews correlation coefficient computed for the given confusion matrix.
+    """
+    pass

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -202,7 +202,13 @@ def __f_score_from_precision_and_recall(
     """
     nominator = precision * recall
     denominator = beta**2 * precision + recall
-    return 0 if denominator is 0 else (1 + beta**2) * nominator / denominator
+
+    if isinstance(denominator, np.ndarray):
+        fscore = (1 + beta**2) * nominator / denominator
+        fscore[np.logical_and(denominator == 0, np.isnan(fscore))] = 0  # replace nan from division by zero with zeros
+        return fscore
+    else:  # scalar case, avoid division by zero for scalar values
+        return 0 if denominator is 0 else (1 + beta**2) * nominator / denominator
 
 
 def fbeta_score(confusion_matrix: np.ndarray, beta: float, average: str | None = None) -> float | np.ndarray[float]:

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -100,12 +100,12 @@ def precision_recall_fscore(
     if average == "micro":  # compute metrics globally
         precision = n_correct / n_samples
         recall = n_correct / n_samples  # identical to precision
-        f_score = __f_score_from_precision_and_recall(precision, recall, beta)  # identical to precision and recall
+        f_score = _f_score_from_precision_and_recall(precision, recall, beta)  # identical to precision and recall
         return precision, recall, f_score
 
     precision_per_class = correct_predictions_per_class / predicted_samples_per_class
     recall_per_class = correct_predictions_per_class / true_samples_per_class
-    f_score_per_class = __f_score_from_precision_and_recall(precision_per_class, recall_per_class, beta)
+    f_score_per_class = _f_score_from_precision_and_recall(precision_per_class, recall_per_class, beta)
 
     if average is None:  # return raw metrics per class without aggregation
         return precision_per_class, recall_per_class, f_score_per_class
@@ -178,7 +178,7 @@ def recall_score(confusion_matrix: np.ndarray, average: str | None = None) -> fl
     return recall
 
 
-def __f_score_from_precision_and_recall(
+def _f_score_from_precision_and_recall(
     precision: float | np.ndarray[float], recall: float | np.ndarray[float], beta: float
 ) -> float | np.ndarray[float]:
     """
@@ -208,7 +208,7 @@ def __f_score_from_precision_and_recall(
         fscore[np.logical_and(denominator == 0, np.isnan(fscore))] = 0  # replace nan from division by zero with zeros
         return fscore
     else:  # scalar case, avoid division by zero for scalar values
-        return 0 if denominator is 0 else (1 + beta**2) * nominator / denominator
+        return 0 if (denominator == 0) else (1 + beta**2) * nominator / denominator
 
 
 def fbeta_score(confusion_matrix: np.ndarray, beta: float, average: str | None = None) -> float | np.ndarray[float]:

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -72,8 +72,8 @@ def precision_recall_fscore(
         The weight of recall in the F score (default: 1.0).
     average : str | None
         How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
-        the scores are aggregated to a single average score. Available averaging methods are: "micro", "samples",
-        "macro", "weighted", and None for no averaging.
+        the scores are aggregated to a single average score. Available averaging methods are: "micro", "macro",
+        "weighted", and None for no averaging.
 
     Returns
     -------
@@ -110,7 +110,7 @@ def precision_recall_fscore(
     if average is None:  # return raw metrics per class without aggregation
         return precision_per_class, recall_per_class, f_score_per_class
 
-    if average == "weight":  # average metrics, class weighted by number of true samples with that label
+    if average == "weighted":  # average metrics, class weighted by number of true samples with that label
         class_weights = true_samples_per_class
     elif average == "macro":  # average metrics, all classes have the same weight
         class_weights = np.ones_like(true_samples_per_class)

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -4,7 +4,8 @@ import numpy as np
 def accuracy_score(confusion_matrix: np.ndarray) -> float:
     """
     Compute overall accuracy from the given confusion matrix, i.e., #correct predictions / #total samples.
-    Based on sklearn.metrics.accuracy_score but computed from the confusion matrix instead of using the
+
+    Based on ``sklearn.metrics.accuracy_score`` but computed from the confusion matrix instead of using the
     sample-wise labels and predictions.
 
     Parameters
@@ -17,15 +18,14 @@ def accuracy_score(confusion_matrix: np.ndarray) -> float:
     float
         The overall accuracy computed for the given confusion matrix.
     """
-    n_samples = confusion_matrix.sum()
-    n_correct = confusion_matrix.diagonal().sum()
-    return n_correct / n_samples
+    return confusion_matrix.trace() / confusion_matrix.sum()
 
 
 def balanced_accuracy_score(confusion_matrix: np.ndarray) -> float:
     """
     Compute the balanced accuracy score as average of the class-wise recalls.
-    Based on sklearn.metrics.balanced_accuracy_score but computed from the confusion matrix instead of using the
+
+    Based on ``sklearn.metrics.balanced_accuracy_score`` but computed from the confusion matrix instead of using the
     sample-wise labels and predictions.
 
     Parameters
@@ -38,7 +38,7 @@ def balanced_accuracy_score(confusion_matrix: np.ndarray) -> float:
     float
         The balanced accuracy computed for the given confusion matrix.
     """
-    # macro average = first compute class-wise recall, then average
+    # Macro average = first compute class-wise recall, then average.
     return recall_score(confusion_matrix, average="macro")
 
 
@@ -48,23 +48,24 @@ def precision_recall_fscore(
     float | np.ndarray[float], float | np.ndarray[float], float | np.ndarray[float]
 ]:
     """
-    Compute the precision, recall, and f-beta score for the given confusion matrix of a multi-class classification
-    model. The three metrics are either returned as class-wise values (if average == None) or averaged using one of the
+    Compute precision, recall, and f-beta score for the given confusion matrix of a multi-class classification model.
+
+    The three metrics are either returned as class-wise values (if ``average == None``) or averaged using one of the
     following methods:
-    - "micro": Metrics are computed globally, i.e. count total true/false positives/negatives for all samples,
+    - ``"micro"``: Metrics are computed globally, i.e., count total true/false positives/negatives for all samples,
       independent of class. This gives **equal importance to each sample** and should result in
       precision == recall == f-score == global accuracy.
-    - "macro": Metrics are first computed independently for each class, the class-wise metrics are then averaged over
-      all classes. This gives **equal importance to each class** but minority classes can outweigh majority classes.
-      With balanced classes, "micro" and "macro" should be identical.
-    - "weighted": Metrics are first computed independently for each class (as for macro), the class-wise metrics are
+    - ``"macro"``: Metrics are first computed independently for each class, the class-wise metrics are then averaged
+      over all classes. This gives **equal importance to each class** but minority classes can outweigh majority
+      classes. With balanced classes, ``"micro"`` and ``"macro"`` should be identical.
+    - ``"weighted"``: Metrics are first computed independently for each class (as for macro), the class-wise metrics are
       then averaged over all classes, each **weighted by their support**. Note that this can result in an F-score that
       is not between precision and recall.
-    This function is for multi-class but not multi-label classification, thus the average options "binary" and "samples"
-    are not included.
+    This function is for multi-class but not multi-label classification, thus the average options ``"binary"`` and
+    ``"samples"`` are not included.
 
-    Based on sklearn.metrics.precision_recall_fscore_support but computed from the confusion matrix instead of using the
-    sample-wise labels and predictions.
+    Based on ``sklearn.metrics.precision_recall_fscore_support`` but computed from the confusion matrix instead of using
+    the sample-wise labels and predictions.
 
     Parameters
     ----------
@@ -73,20 +74,20 @@ def precision_recall_fscore(
     beta : float
         The weight of recall in the F score (default: 1.0).
     average : str | None
-        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
-        the scores are aggregated to a single average score. Available averaging methods are: "micro", "macro",
-        "weighted", and None for no averaging.
+        How to aggregate over classes. If ``None`` (default), the scores for each class are returned as array.
+        Otherwise, the scores are aggregated to a single average score. Available averaging methods are: ``"micro"``,
+        ``"macro"``, ``"weighted"``, and ``None`` for no averaging.
 
     Returns
     -------
     float | np.ndarray[float]
-        The precision score either class-wise (if average == None) or averaged over all classes using the specified
+        The precision score either class-wise (if ``average == None``) or averaged over all classes using the specified
         averaging method.
     float | np.ndarray[float]
-        The recall score either class-wise (if average == None) or averaged over all classes using the specified
+        The recall score either class-wise (if ``average == None``) or averaged over all classes using the specified
         averaging method.
     float | np.ndarray[float]
-        The f-beta score either class-wise (if average == None) or averaged over all classes using the specified
+        The f-beta score either class-wise (if ``average == None``) or averaged over all classes using the specified
         averaging method.
     """
     n_samples = confusion_matrix.sum()
@@ -98,17 +99,17 @@ def precision_recall_fscore(
             f"Invalid {average=}. Supported averages are: {supported_averages}."
         )
 
-    if average == "micro":  # compute metrics globally
+    if average == "micro":  # Compute metrics globally.
         accuracy = n_correct / n_samples
         return (
             accuracy,
             accuracy,
             accuracy,
-        )  # precision, recall, f_score are all the same
+        )  # Precision, recall, and F score are all the same.
 
     predicted_samples_per_class = confusion_matrix.sum(axis=0)
     true_samples_per_class = confusion_matrix.sum(axis=1)
-    correct_predictions_per_class = confusion_matrix.diagonal()  # true positives
+    correct_predictions_per_class = confusion_matrix.diagonal()  # True positives
     false_positives_per_class = (
         predicted_samples_per_class - correct_predictions_per_class
     )
@@ -116,7 +117,7 @@ def precision_recall_fscore(
 
     precision_per_class = correct_predictions_per_class / predicted_samples_per_class
     recall_per_class = correct_predictions_per_class / true_samples_per_class
-    # using the f-score definition (1+β²) TP / ((1+β²) TP + β² FN + FP)
+    # Using the F-score definition (1+β²) TP / ((1+β²) TP + β² FN + FP):
     nominator = (1 + beta**2) * correct_predictions_per_class  # (1+β²) TP
     denominator = (  # ((1+β²) TP + β² FN + FP)
         (1 + beta**2) * correct_predictions_per_class
@@ -125,19 +126,38 @@ def precision_recall_fscore(
     )
     f_score_per_class = nominator / denominator
 
-    if average is None:  # return raw metrics per class without aggregation
+    if average is None:  # Return raw metrics per class without aggregation.
         return precision_per_class, recall_per_class, f_score_per_class
 
     if (
         average == "weighted"
-    ):  # average metrics, class weighted by number of true samples with that label
+    ):  # Average metrics, class weighted by number of true samples with that label.
         class_weights = true_samples_per_class
-    elif average == "macro":  # average metrics, all classes have the same weight
+    elif average == "macro":  # Average metrics, all classes have the same weight.
         class_weights = np.ones_like(true_samples_per_class)
     else:
         raise ValueError(f"No class weights supported for {average=}.")
 
-    def average_with_weights(weights, values):
+    def average_with_weights(
+        weights: np.ndarray, values: np.ndarray
+    ) -> tuple[
+        float | np.ndarray[float], float | np.ndarray[float], float | np.ndarray[float]
+    ]:
+        """
+        Calculate average with provided weights.
+
+        Parameters
+        ----------
+        weights : np.ndarray
+            The weights.
+        values : np.ndarray
+            The values to average.
+
+        Returns
+        -------
+        float
+            The weighted average.
+        """
         return (weights * values).sum() / weights.sum()
 
     precision = average_with_weights(class_weights, precision_per_class)
@@ -150,9 +170,10 @@ def precision_score(
     confusion_matrix: np.ndarray, average: str | None = None
 ) -> float | np.ndarray[float]:
     """
-    Compute the precision score for the given confusion matrix of a multi-class classification model. The result is
-    either returned as class-wise values (if average == None) or averaged.
-    Based on sklearn.metrics.precision_score but computed from the confusion matrix instead of using the
+    Compute the precision score for the given confusion matrix of a multi-class classification model.
+
+    The result is either returned as class-wise values (if ``average == None``) or averaged.
+    Based on ``sklearn.metrics.precision_score`` but computed from the confusion matrix instead of using the
     sample-wise labels and predictions.
 
     Parameters
@@ -160,14 +181,14 @@ def precision_score(
     confusion_matrix : np.ndarray
         The multi-class classification confusion matrix (non-normalized).
     average : str | None
-        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
-        the scores are aggregated to a single average score. See precision_recall_fscore for more details on the
-        available averaging methods.
+        How to aggregate over classes. If ``None`` (default), the scores for each class are returned as array.
+        Otherwise, the scores are aggregated to a single average score. See ``precision_recall_fscore`` for more details
+        on the available averaging methods.
 
     Returns
     -------
     float | np.ndarray[float]
-        The precision score either class-wise (if average == None) or averaged over all classes using the specified
+        The precision score either class-wise (if ``average == None``) or averaged over all classes using the specified
         averaging method.
     """
     precision, _, _ = precision_recall_fscore(confusion_matrix, average=average)
@@ -178,9 +199,10 @@ def recall_score(
     confusion_matrix: np.ndarray, average: str | None = None
 ) -> float | np.ndarray[float]:
     """
-    Compute the recall score for the given confusion matrix of a multi-class classification model. The result is either
-    returned as class-wise values (if average == None) or averaged.
-    Based on sklearn.metrics.recall_score but computed from the confusion matrix instead of using the
+    Compute the recall score for the given confusion matrix of a multi-class classification model.
+
+    The result is either returned as class-wise values (if ``average == None``) or averaged.
+    Based on ``sklearn.metrics.recall_score`` but computed from the confusion matrix instead of using the
     sample-wise labels and predictions.
 
     Parameters
@@ -188,9 +210,9 @@ def recall_score(
     confusion_matrix : np.ndarray
         The multi-class classification confusion matrix (non-normalized).
     average : str | None
-        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
-        the scores are aggregated to a single average score. See precision_recall_fscore for more details on the
-        available averaging methods.
+        How to aggregate over classes. If ``None`` (default), the scores for each class are returned as array.
+        Otherwise, the scores are aggregated to a single average score. See ``precision_recall_fscore`` for more details
+        on the available averaging methods.
 
     Returns
     -------
@@ -206,9 +228,10 @@ def fbeta_score(
     confusion_matrix: np.ndarray, beta: float, average: str | None = None
 ) -> float | np.ndarray[float]:
     """
-    Compute the F-beta score for the given confusion matrix of a multi-class classification model. The result is either
-    returned as class-wise values (if average == None) or averaged.
-    Based on sklearn.metrics.fbeta_score but computed from the confusion matrix instead of using the
+    Compute the F-beta score for the given confusion matrix of a multi-class classification model.
+
+    The result is either returned as class-wise values (if ``average == None``) or averaged.
+    Based on ``sklearn.metrics.fbeta_score`` but computed from the confusion matrix instead of using the
     sample-wise labels and predictions.
 
     Parameters
@@ -218,14 +241,14 @@ def fbeta_score(
     beta : float
         The weight of recall in the F score.
     average : str | None
-        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
-        the scores are aggregated to a single average score. See precision_recall_fscore for more details on the
-        available averaging methods.
+        How to aggregate over classes. If ``None`` (default), the scores for each class are returned as array.
+        Otherwise, the scores are aggregated to a single average score. See precision_recall_fscore for more details on
+        the available averaging methods.
 
     Returns
     -------
     float | np.ndarray[float]
-        The f-beta score either class-wise (if average == None) or averaged over all classes using the specified
+        The f-beta score either class-wise (if ``average == None``) or averaged over all classes using the specified
         averaging method.
     """
     _, _, f_score = precision_recall_fscore(
@@ -238,9 +261,10 @@ def f1_score(
     confusion_matrix: np.ndarray, average: str | None = None
 ) -> float | np.ndarray[float]:
     """
-    Compute the F1 score for the given confusion matrix of a multi-class classification model. The result is either
-    returned as class-wise values (if average == None) or averaged.
-    Based on sklearn.metrics.f1_score but computed from the confusion matrix instead of using the
+    Compute the F1 score for the given confusion matrix of a multi-class classification model.
+
+    The result is either returned as class-wise values (if ``average == None``) or averaged.
+    Based on ``sklearn.metrics.f1_score`` but computed from the confusion matrix instead of using the
     sample-wise labels and predictions.
 
     Parameters
@@ -248,14 +272,14 @@ def f1_score(
     confusion_matrix : np.ndarray
         The multi-class classification confusion matrix (non-normalized).
     average : str | None
-        How to aggregate over classes. If None (default), the scores for each class are returned as array. Otherwise,
-        the scores are aggregated to a single average score. See precision_recall_fscore for more details on the
-        available averaging methods.
+        How to aggregate over classes. If ``None`` (default), the scores for each class are returned as array.
+        Otherwise, the scores are aggregated to a single average score. See ``precision_recall_fscore`` for more details
+        on the available averaging methods.
 
     Returns
     -------
     float | np.ndarray[float]
-        The F1 score either class-wise (if average == None) or averaged over all classes using the specified
+        The F1 score either class-wise (if ``average == None``) or averaged over all classes using the specified
         averaging method.
     """
     return fbeta_score(confusion_matrix, beta=1, average=average)
@@ -263,9 +287,9 @@ def f1_score(
 
 def cohen_kappa_score(confusion_matrix: np.ndarray) -> float:
     """
-    Compute Cohen’s kappa, a measure for agreement between two annotators on a classification problem, for the given
-    confusion matrix.
-    Based on sklearn.metrics.cohen_kappa_score but computed from the confusion matrix instead of using the
+    Compute Cohen’s kappa, a measure for agreement between two annotators on a classification problem.
+
+    Based on ``sklearn.metrics.cohen_kappa_score`` but computed from the confusion matrix instead of using the
     sample-wise labels and predictions.
 
     Parameters
@@ -301,7 +325,8 @@ def cohen_kappa_score(confusion_matrix: np.ndarray) -> float:
 def matthews_corrcoef(confusion_matrix: np.ndarray) -> float:
     """
     Compute Matthews correlation coefficient (MCC) for the given confusion matrix.
-    Based on sklearn.metrics.matthews_corrcoef but computed from the confusion matrix instead of using the
+
+    Based on ``sklearn.metrics.matthews_corrcoef`` but computed from the confusion matrix instead of using the
     sample-wise labels and predictions.
 
     Parameters

--- a/specialcouscous/evaluation_metrics.py
+++ b/specialcouscous/evaluation_metrics.py
@@ -248,4 +248,15 @@ def matthews_corrcoef(confusion_matrix: np.ndarray) -> float:
     float
         The Matthews correlation coefficient computed for the given confusion matrix.
     """
-    pass
+    predicted_samples_per_class = confusion_matrix.sum(axis=0)  # = p_k
+    true_samples_per_class = confusion_matrix.sum(axis=1)  # = t_k
+    n_samples = confusion_matrix.sum()  # = s
+    n_correct = confusion_matrix.trace()  # = c
+
+    # MCC = (c * s - t • p) / (sqrt(s^2 - p • p) * sqrt(s^2 - t • t))
+    nominator_tp = n_correct * n_samples - np.dot(true_samples_per_class, predicted_samples_per_class)  # c * s - t•p
+    denominator_predicted = n_samples**2 - np.dot(predicted_samples_per_class, predicted_samples_per_class)  # s^2 - p•p
+    denominator_true = n_samples**2 - np.dot(true_samples_per_class, true_samples_per_class)  # s^2 - t•t
+    denominator = np.sqrt(denominator_predicted * denominator_true)  # sqrt(s^2 - p • p) * sqrt(s^2 - t • t)
+
+    return 0 if denominator == 0 else nominator_tp / denominator  # MCC = (c*s - t•p) / sqrt((s^2 - p•p) * (s^2 - t•t))

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -5,6 +5,7 @@ import sklearn.metrics
 from specialcouscous import evaluation_metrics
 
 
+@pytest.mark.parametrize('n_classes', [2, 10, 100])
 class TestEvaluationMetrics:
     @staticmethod
     def first_and_fill_rest(first: float, fill: float, total_length: int) -> np.ndarray[float]:
@@ -28,7 +29,7 @@ class TestEvaluationMetrics:
         """
         return np.concat([np.array([first]), np.full(total_length - 1, fill)])
 
-    def test_accuracy_score(self, n_classes=10):
+    def test_accuracy_score(self, n_classes):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -47,7 +48,7 @@ class TestEvaluationMetrics:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             assert evaluation_metrics.accuracy_score(confusion_matrix) == expected_accuracy
 
-    def test_balanced_accuracy_score(self, n_classes=10):
+    def test_balanced_accuracy_score(self, n_classes):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -66,7 +67,7 @@ class TestEvaluationMetrics:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             assert evaluation_metrics.balanced_accuracy_score(confusion_matrix) == expected_accuracy
 
-    def test_precision_recall_fscore__totally_balanced(self, n_classes=10):
+    def test_precision_recall_fscore__totally_balanced(self, n_classes):
         # 100% balanced case: all classes have equal share of the labels and equal class wise accuracy
         classes = np.arange(n_classes)
         y_true = np.tile(classes, 5)  # each class appears 5 times
@@ -88,7 +89,7 @@ class TestEvaluationMetrics:
             for actual_score in actual_scores:
                 assert actual_score == pytest.approx(expected_class_wise_accuracy, 1e-6)
 
-    def test_precision_recall_fscore__balanced_labels_imbalanced_predictions(self, n_classes=10):
+    def test_precision_recall_fscore__balanced_labels_imbalanced_predictions(self, n_classes):
         # balanced labels but imbalanced accuracy: class labels are balanced but different class-wise accuracies
         y_true = np.arange(n_classes).repeat(n_classes)  # each class appears n_classes times, consecutively
         # Class i is predicted correctly (n_classes - i) times (i.e. the larger i, the lower the recall,
@@ -131,7 +132,7 @@ class TestEvaluationMetrics:
                 expected = expected_class_wise.mean()
                 assert actual == pytest.approx(expected, 1e-6)
 
-    def test_precision_recall_fscore__imbalanced(self, n_classes=10):
+    def test_precision_recall_fscore__imbalanced(self, n_classes):
         # completely imbalanced: both class labels and class accuracies are imbalanced
         # class i appears (i + 1) * 2 times, consecutively
         y_true = np.concat([np.full((i + 1) * 2, i) for i in range(n_classes)])
@@ -182,7 +183,7 @@ class TestEvaluationMetrics:
             expected = (expected_class_wise * class_weights).sum() / class_weights.sum()
             assert actual == pytest.approx(expected, 1e-6)
 
-    def test_precision_score(self, n_classes=10):
+    def test_precision_score(self, n_classes):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -207,7 +208,7 @@ class TestEvaluationMetrics:
             actual_precision = evaluation_metrics.precision_score(confusion_matrix)
             np.testing.assert_array_equal(actual_precision, expected_precision, strict=True)
 
-    def test_recall_score(self, n_classes=10):
+    def test_recall_score(self, n_classes):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -229,7 +230,7 @@ class TestEvaluationMetrics:
             actual_recall = evaluation_metrics.recall_score(confusion_matrix)
             np.testing.assert_array_equal(actual_recall, expected_recall, strict=True)
 
-    def test___f_score_from_precision_and_recall(self):
+    def test___f_score_from_precision_and_recall(self, n_classes):
         # scalar inputs
         precision_recall_beta_expected_fscore = [  # if precision == recall, fscore == precision == recall
             (precision_recall, precision_recall, beta, precision_recall)
@@ -253,7 +254,7 @@ class TestEvaluationMetrics:
         actual_fscores = evaluation_metrics._f_score_from_precision_and_recall(precisions, recalls, betas)
         np.testing.assert_allclose(actual_fscores, expected_fscores, atol=epsilon, strict=True)
 
-    def test_fbeta_score(self, n_classes=10, beta=2):
+    def test_fbeta_score(self, n_classes, beta=2):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -285,7 +286,7 @@ class TestEvaluationMetrics:
             actual_fbeta = evaluation_metrics.fbeta_score(confusion_matrix, beta=beta)
             np.testing.assert_array_equal(actual_fbeta, expected_fbeta, strict=True)
 
-    def test_f1_score(self, n_classes=10):
+    def test_f1_score(self, n_classes):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [
@@ -309,7 +310,7 @@ class TestEvaluationMetrics:
             expected_f1 = evaluation_metrics.fbeta_score(confusion_matrix, beta=1)
             np.testing.assert_array_equal(actual_f1, expected_f1, strict=True)
 
-    def test_cohen_kappa_score(self, n_classes=10):
+    def test_cohen_kappa_score(self, n_classes):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [
@@ -332,7 +333,7 @@ class TestEvaluationMetrics:
             expected_kappa = sklearn.metrics.cohen_kappa_score(y_true, y_pred)
             assert actual_kappa == pytest.approx(expected_kappa, 1e-6)
 
-    def test_matthews_corrcoef(self, n_classes=10):
+    def test_matthews_corrcoef(self, n_classes):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -129,12 +129,29 @@ class TestEvaluationMetrics:
             actual_recall = evaluation_metrics.recall_score(confusion_matrix)
             np.testing.assert_array_equal(actual_recall, expected_recall, strict=True)
 
-    @pytest.mark.skip("Test not yet implemented.")
     def test___f_score_from_precision_and_recall(self):
         # scalar inputs
+        precision_recall_beta_expected_fscore = [  # if precision == recall, fscore == precision == recall
+            (precision_recall, precision_recall, beta, precision_recall)
+            for precision_recall in [0, 0.5, 1] for beta in [0.1, 1, 10]
+        ] + [
+            (1, 0, 1, 0),
+            (0, 1, 1, 0),
+            (0.25, 0.75, 1, 0.375),
+            (0.75, 0.25, 1, 0.375),
+            (0.25, 0.75, 10, 0.735),  # epsilon = 1e-2
+            (0.75, 0.25, 10, 0.252),  # epsilon = 1e-2
+        ]
+        epsilon = 1e-2
+        for precision, recall, beta, expected_fscore in precision_recall_beta_expected_fscore:
+            actual_fscore = evaluation_metrics._f_score_from_precision_and_recall(precision, recall, beta)
+            assert actual_fscore == pytest.approx(expected_fscore, epsilon)
 
         # array inputs
-        pass  # TODO: implement this test
+        precisions, recalls, betas, expected_fscores = [
+            np.array(values) for values in zip(*precision_recall_beta_expected_fscore)]
+        actual_fscores = evaluation_metrics._f_score_from_precision_and_recall(precisions, recalls, betas)
+        np.testing.assert_allclose(actual_fscores, expected_fscores, atol=epsilon, strict=True)
 
     def test_fbeta_score(self, n_classes=10, beta=2):
         # balanced case

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -1,0 +1,45 @@
+import numpy as np
+import sklearn.metrics
+
+from specialcouscous import evaluation_metrics
+
+
+class TestEvaluationMetrics:
+    def test_accuracy_score(self, n_classes=10):
+        # balanced case
+        y_true = np.arange(n_classes).repeat(5)
+        labels_prediction_and_expected_accuracy = [
+            (y_true, y_true, 1),  # all correct
+            (y_true, (y_true + 1) % n_classes, 0),  # all false
+            (y_true, np.zeros_like(y_true), 0.1),  # all zero = only first correct
+        ]
+        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
+        labels_prediction_and_expected_accuracy += [
+            (y_true, y_true, 1),  # all correct
+            (y_true, (y_true + 1) % n_classes, 0),  # all false
+            (y_true, np.zeros_like(y_true), (1 + n_classes) / (2 * n_classes)),  # all zero = only first correct
+        ]
+        for y_true, y_pred, expected_accuracy in labels_prediction_and_expected_accuracy:
+            confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
+            assert evaluation_metrics.accuracy_score(confusion_matrix) == expected_accuracy
+
+    def test_balanced_accuracy_score(self, n_classes=10):
+        # balanced case
+        y_true = np.arange(n_classes).repeat(5)
+        labels_prediction_and_expected_accuracy = [
+            (y_true, y_true, 1),  # all correct
+            (y_true, (y_true + 1) % n_classes, 0),  # all false
+            (y_true, np.zeros_like(y_true), 0.1),  # all zero = only first correct
+        ]
+        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
+        labels_prediction_and_expected_accuracy += [
+            (y_true, y_true, 1),  # all correct
+            (y_true, (y_true + 1) % n_classes, 0),  # all false
+            (y_true, np.zeros_like(y_true), 0.1),  # all zero = only first correct
+        ]
+        for y_true, y_pred, expected_accuracy in labels_prediction_and_expected_accuracy:
+            confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
+            assert evaluation_metrics.balanced_accuracy_score(confusion_matrix) == expected_accuracy
+

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -7,18 +7,17 @@ from specialcouscous import evaluation_metrics
 
 @pytest.mark.parametrize("n_classes", [2, 10, 100])
 class TestEvaluationMetrics:
-    """
-    Test class to test all multi-class evaluation metrics defined in evaluation_metrics.py for different numbers of
-    classes (at least two).
-    """
+    """Test class to test all multi-class evaluation metrics for different numbers of classes (at least two)."""
 
     @staticmethod
     def first_and_fill_rest(
         first: float, fill: float, total_length: int
     ) -> np.ndarray[float]:
         """
-        Create a numpy array (1D) of length total_length where the first value is first and all remaining values are
-        filled with the specified fill value.
+        Create a numpy array (1D) for testing.
+
+        The array has ``length total_length`` elements where the first value is `` first and all remaining values are
+        filled with the specified fill value ``fill``.
 
         Parameters
         ----------
@@ -32,41 +31,42 @@ class TestEvaluationMetrics:
         Returns
         -------
         np.ndarray[float]
-            The created array [first, fill, ... fill] of length total_length.
+            The created array [first, fill, ... fill] of ``length total_length``.
         """
         return np.concat([np.array([first]), np.full(total_length - 1, fill)])
 
     def test_accuracy_score(self, n_classes: int) -> None:
         """
-        Test the accuracy score metric for a variable number of classes in both balanced and unbalanced cases. Comparing
-        both to a manual expected value and the sklearn equivalent.
+        Test the accuracy score metric for a variable number of classes in both balanced and unbalanced cases.
+
+        Comparing both to a manual expected value and the ``sklearn`` equivalent.
 
         Parameters
         ----------
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # balanced case
+        # Balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
-            (y_true, y_true, 1),  # all correct
-            (y_true, (y_true + 1) % n_classes, 0),  # all false
+            (y_true, y_true, 1),  # All correct
+            (y_true, (y_true + 1) % n_classes, 0),  # All false
             (
                 y_true,
                 np.zeros_like(y_true),
                 1 / n_classes,
-            ),  # all zero = only first correct
+            ),  # All zero = only first correct
         ]
-        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        # Imbalanced case: Each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_prediction_and_expected_accuracy += [
-            (y_true, y_true, 1),  # all correct
-            (y_true, (y_true + 1) % n_classes, 0),  # all false
+            (y_true, y_true, 1),  # All correct
+            (y_true, (y_true + 1) % n_classes, 0),  # All false
             (
                 y_true,
                 np.zeros_like(y_true),
                 (1 + n_classes) / (2 * n_classes),
-            ),  # all zero = only first correct
+            ),  # All zero = only first correct
         ]
         for (
             y_true,
@@ -81,35 +81,36 @@ class TestEvaluationMetrics:
 
     def test_balanced_accuracy_score(self, n_classes: int) -> None:
         """
-        Test the balanced accuracy score metric for a variable number of classes in both balanced and unbalanced cases.
-        Comparing both to a manual expected value and the sklearn equivalent.
+        Test the balanced accuracy score metric for a variable number of classes in both balanced and imbalanced cases.
+
+        Comparing both to a manual expected value and the ``sklearn`` equivalent.
 
         Parameters
         ----------
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # balanced case
+        # Balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
-            (y_true, y_true, 1),  # all correct
-            (y_true, (y_true + 1) % n_classes, 0),  # all false
+            (y_true, y_true, 1),  # All correct
+            (y_true, (y_true + 1) % n_classes, 0),  # All false
             (
                 y_true,
                 np.zeros_like(y_true),
                 1 / n_classes,
-            ),  # all zero = only first correct
+            ),  # All zero = only first correct
         ]
-        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        # Imbalanced case: Each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_prediction_and_expected_accuracy += [
-            (y_true, y_true, 1),  # all correct
-            (y_true, (y_true + 1) % n_classes, 0),  # all false
+            (y_true, y_true, 1),  # All correct
+            (y_true, (y_true + 1) % n_classes, 0),  # All false
             (
                 y_true,
                 np.zeros_like(y_true),
                 1 / n_classes,
-            ),  # all zero = only first correct
+            ),  # All zero = only first correct
         ]
         for (
             y_true,
@@ -128,19 +129,20 @@ class TestEvaluationMetrics:
 
     def test_precision_recall_fscore__totally_balanced(self, n_classes: int) -> None:
         """
-        Test the precision_recall_fscore metric in the 100% balanced case: all classes have equal share of the labels
-        and equal class wise accuracy.
-        Comparing both to a manual expected value and the sklearn (near-)equivalent precision_recall_fscore_support.
+        Test the ``precision_recall_fscore`` metric in the 100% balanced case.
+
+        All classes have equal share of the labels and equal class wise accuracy. Comparing both to a manual expected
+        value and the ``sklearn`` (near-)equivalent ``precision_recall_fscore_support``.
 
         Parameters
         ----------
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # 100% balanced case: all classes have equal share of the labels and equal class wise accuracy
+        # 100% balanced case: All classes have equal share of the labels and equal class wise accuracy.
         classes = np.arange(n_classes)
-        y_true = np.tile(classes, 5)  # each class appears 5 times
-        # each class is predicted correcting 3 / 5 times -> class-wise accuracy is 60% for all classes
+        y_true = np.tile(classes, 5)  # Each class appears 5 times.
+        # Each class is predicted correctly 3 / 5 times -> class-wise accuracy is 60% for all classes.
         y_pred = np.concat([np.tile(classes, 3), (np.tile(classes, 2) + 1) % n_classes])
 
         expected_class_wise_accuracy = 0.6
@@ -149,7 +151,7 @@ class TestEvaluationMetrics:
         )
         confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
 
-        # no average = class-wise scores, all scores are identical because everything is balanced
+        # No average = class-wise scores; all scores are identical because everything is balanced.
         actual = evaluation_metrics.precision_recall_fscore(confusion_matrix)
         expected_sklearn = sklearn.metrics.precision_recall_fscore_support(
             y_true, y_pred
@@ -162,7 +164,7 @@ class TestEvaluationMetrics:
                 actual_score_array, expected_sklearn_array, strict=True
             )
 
-        # all averages are identical because everything is balanced
+        # All averages are identical because everything is balanced.
         for average in ["micro", "macro", "weighted"]:
             actual_scores = evaluation_metrics.precision_recall_fscore(
                 confusion_matrix, average=average
@@ -180,23 +182,24 @@ class TestEvaluationMetrics:
         self, n_classes: int
     ) -> None:
         """
-        Test the precision_recall_fscore metric in the case where the class labels are balanced but the classes have
-        different class-wise accuracies.
-        Comparing both to a manual expected value and the sklearn (near-)equivalent precision_recall_fscore_support.
+        Test the ``precision_recall_fscore metric`` with balanced class labels but different class-wise accuracies.
+
+        Comparing both to a manual expected value and the ``sklearn`` (near-)equivalent
+        ``precision_recall_fscore_support``.
 
         Parameters
         ----------
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # balanced labels but imbalanced accuracy: class labels are balanced but different class-wise accuracies
+        # Balanced labels but imbalanced accuracy: Class labels are balanced but different class-wise accuracies.
         y_true = np.arange(n_classes).repeat(
             n_classes
-        )  # each class appears n_classes times, consecutively
-        # Class i is predicted correctly (n_classes - i) times (i.e. the larger i, the lower the recall,
-        # class 0 has recall 1). All incorrect predictions predict class 0 instead. (i.e. class 0 has low precision,
-        # all other classes have precision 1)
-        # To achieve this, we interpret the labels as square matrix (n_classes x n_classes, each row corresponds to on
+        )  # Each class appears `n_classes` times, consecutively.
+        # Class i is predicted correctly (n_classes - i) times (i.e., the larger i, the lower the recall,
+        # class 0 has recall 1). All incorrect predictions predict class 0 instead (i.e., class 0 has low precision,
+        # all other classes have precision 1).
+        # To achieve this, we interpret the labels as square matrix (n_classes x n_classes, each row corresponds to one
         # class) and take the upper triangular matrix by setting all values below the diagonal to zero. Flattening this
         # matrix results in predicting zero the first i times for class i and i the remaining n_classes - i times.
         y_pred = np.triu(y_true.reshape(n_classes, n_classes)).flatten()
@@ -222,7 +225,7 @@ class TestEvaluationMetrics:
 
         confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
 
-        # no average = class-wise scores, all scores are identical because everything is balanced
+        # No average = class-wise scores, all scores are identical because everything is balanced.
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
             confusion_matrix
         )
@@ -237,7 +240,7 @@ class TestEvaluationMetrics:
             np.testing.assert_allclose(actual, expected_manual, atol=1e-6, strict=True)
             np.testing.assert_allclose(actual, expected_sklearn, atol=1e-6, strict=True)
 
-        # micro average of recall, precision, and f1 are all identical to the overall accuracy
+        # Micro average of recall, precision, and F1 are all identical to the overall accuracy.
         expected_overall_accuracy = correct_predictions / total_predictions
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
             confusion_matrix, average="micro"
@@ -251,7 +254,7 @@ class TestEvaluationMetrics:
             assert actual == pytest.approx(expected_overall_accuracy, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
-        # macro average: mean of class-wise scores, weighted average identical since true class distribution is balanced
+        # Macro average: Mean of class-wise scores, weighted average identical since true class distribution is balanced
         for average in ["macro", "weighted"]:
             actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
                 confusion_matrix, average=average
@@ -270,25 +273,26 @@ class TestEvaluationMetrics:
 
     def test_precision_recall_fscore__imbalanced(self, n_classes: int) -> None:
         """
-        Test the precision_recall_fscore metric in the imbalanced case where both class labels and class accuracies are
-        imbalanced.
-        Comparing both to a manual expected value and the sklearn (near-)equivalent precision_recall_fscore_support.
+        Test ``precision_recall_fscore`` in the imbalanced case with both imbalanced class labels and class accuracies.
+
+        Comparing both to a manual expected value and the ``sklearn`` (near-)equivalent
+        ``precision_recall_fscore_support``.
 
         Parameters
         ----------
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # completely imbalanced: both class labels and class accuracies are imbalanced
-        # class i appears (i + 1) * 2 times, consecutively
+        # Completely imbalanced: Both class labels and class accuracies are imbalanced.
+        # Class i appears (i + 1) * 2 times, consecutively.
         y_true = np.concat([np.full((i + 1) * 2, i) for i in range(n_classes)])
-        # class i is predicted correctly (i + 1) times (-> recall 50%).
-        # when class is not predicted correctly, class (i + 1) % n_classes is predicted instead
+        # Class i is predicted correctly (i + 1) times (-> recall 50%).
+        # When class is not predicted correctly, class (i + 1) % n_classes is predicted instead
         # (-> class i is predicted (i + 1) times correctly and ((i - 1) % n_classes + 1) times incorrectly, when
         # class (i - 1) % n_classes should have been predicted instead.
         # -> precision (i + 1) / (2i + 1) for i > 0 and 1 / (n + 1) for i = 0)
         # To achieve this, the first half of occurrences for each class are predicted correctly while for the second
-        # half, the next class is predicted
+        # half, the next class is predicted.
         y_pred = np.concat(
             [
                 x
@@ -332,7 +336,7 @@ class TestEvaluationMetrics:
             np.testing.assert_allclose(actual, expected_manual, atol=1e-6, strict=True)
             np.testing.assert_allclose(actual, expected_sklearn, atol=1e-6, strict=True)
 
-        # micro average of recall, precision, and f1 are all identical to the overall accuracy
+        # Micro average of recall, precision, and F1 are all identical to the overall accuracy.
         expected_overall_accuracy = correct_predictions / total_predictions
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
             confusion_matrix, average="micro"
@@ -346,7 +350,7 @@ class TestEvaluationMetrics:
             assert actual == pytest.approx(expected_overall_accuracy, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
-        # macro average: mean of class-wise scores
+        # Macro average: Mean of class-wise scores
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
             confusion_matrix, average="macro"
         )
@@ -362,7 +366,7 @@ class TestEvaluationMetrics:
             assert actual == pytest.approx(expected_manual, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
-        # weighted average: mean of class-wise scores
+        # Weighted average: Mean of class-wise scores
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
             confusion_matrix, average="weighted"
         )
@@ -382,7 +386,7 @@ class TestEvaluationMetrics:
 
     def test_precision_recall_fscore__invalid_average(self, n_classes: int) -> None:
         """
-        Test precision_recall_fscore with invalid average parameters. Should raise a ValueError.
+        Test ``precision_recall_fscore`` with invalid average parameters. Should raise a ``ValueError``.
 
         Parameters
         ----------
@@ -395,25 +399,27 @@ class TestEvaluationMetrics:
         for invalid_average in invalid_averages:
             with pytest.raises(ValueError):
                 evaluation_metrics.precision_recall_fscore(
-                    confusion_matrix, average=invalid_average
+                    confusion_matrix,
+                    average=invalid_average,  # type: ignore
                 )
 
     def test_precision_score(self, n_classes: int) -> None:
         """
         Test the precision score metric for a variable number of classes in both balanced and unbalanced cases.
-        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Comparing both to a manual expected value and the ``sklearn`` equivalent.
 
         Parameters
         ----------
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # balanced case
+        # Balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
-            (y_true, y_true, np.ones(n_classes)),  # all correct
-            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
-            # all zero: for first class: 5 correct predictions, but also 5 * (n_classes - 1) incorrect predictions
+            (y_true, y_true, np.ones(n_classes)),  # All correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # All false
+            # All zero: for first class: 5 correct predictions, but also 5 * (n_classes - 1) incorrect predictions
             # -> 1 / n_classes, no prediction at all for all other classes -> nan
             (
                 y_true,
@@ -421,13 +427,13 @@ class TestEvaluationMetrics:
                 self.first_and_fill_rest(1 / n_classes, np.nan, n_classes),
             ),
         ]
-        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        # Imbalanced case: Each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         n_samples = 2 * n_classes
         labels_prediction_and_expected_accuracy += [
-            (y_true, y_true, np.ones(n_classes)),  # all correct
-            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
-            # all zero: for first class: 5 * (1 + n_classes) correct predictions, but also n_classes - 1 incorrect
+            (y_true, y_true, np.ones(n_classes)),  # All correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # All false
+            # All zero: for first class: 5 * (1 + n_classes) correct predictions, but also n_classes - 1 incorrect
             # predictions -> (1 + n_classes) / (2 * n_classes), no prediction at all for all other classes -> nan
             (
                 y_true,
@@ -457,6 +463,7 @@ class TestEvaluationMetrics:
     def test_recall_score(self, n_classes: int) -> None:
         """
         Test the recall score metric for a variable number of classes in both balanced and unbalanced cases.
+
         Comparing both to a manual expected value and the sklearn equivalent.
 
         Parameters
@@ -464,24 +471,24 @@ class TestEvaluationMetrics:
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # balanced case
+        # Balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
             (y_true, y_true, np.ones(n_classes)),  # all correct
             (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
-            # all zero: only first class correct
+            # All zero: only first class correct
             (
                 y_true,
                 np.zeros_like(y_true),
                 self.first_and_fill_rest(1.0, 0.0, n_classes),
             ),
         ]
-        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        # Imbalanced case: Each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_prediction_and_expected_accuracy += [
-            (y_true, y_true, np.ones(n_classes)),  # all correct
-            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
-            # all zero: only first class correct
+            (y_true, y_true, np.ones(n_classes)),  # All correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # All false
+            # All zero: only first class correct
             (
                 y_true,
                 np.zeros_like(y_true),
@@ -508,9 +515,9 @@ class TestEvaluationMetrics:
     @pytest.mark.parametrize("beta", [0.5, 1, 10, 100])
     def test_fbeta_score(self, n_classes: int, beta: float) -> None:
         """
-        Test the balanced accuracy score metric for a variable number of classes and betas in both balanced and
-        unbalanced cases.
-        Comparing both to a manual expected value and the sklearn equivalent.
+        Test the balanced accuracy score in both balanced and imbalanced cases.
+
+        Comparing both to a manual expected value and the ``sklearn`` equivalent.
 
         Parameters
         ----------
@@ -519,13 +526,13 @@ class TestEvaluationMetrics:
         beta : float
             The beta parameter of the F-beta score.
         """
-        # balanced case
+        # Balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
-            (y_true, y_true, np.ones(n_classes)),  # all correct
-            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
+            (y_true, y_true, np.ones(n_classes)),  # All correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # All false
         ]
-        # all zero: only first class correct
+        # All zero: Only first class correct
         precision = 1 / n_classes
         recall = 1
         f_beta = (1 + beta**2) * (precision * recall) / (beta**2 * precision + recall)
@@ -534,13 +541,13 @@ class TestEvaluationMetrics:
             (y_true, np.zeros_like(y_true), expected)
         ]
 
-        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        # Imbalanced case: Each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_prediction_and_expected_accuracy += [
-            (y_true, y_true, np.ones(n_classes)),  # all correct
-            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
+            (y_true, y_true, np.ones(n_classes)),  # All correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # All false
         ]
-        # all zero: only first class correct
+        # All zero: Only first class correct
         precision = (1 + n_classes) / (2 * n_classes)
         recall = 1
         f_beta = (1 + beta**2) * (precision * recall) / (beta**2 * precision + recall)
@@ -569,33 +576,34 @@ class TestEvaluationMetrics:
     def test_f1_score(self, n_classes: int) -> None:
         """
         Test the F1 score metric for a variable number of classes in both balanced and unbalanced cases.
-        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Comparing both to a manual expected value and the ``sklearn`` equivalent.
 
         Parameters
         ----------
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # balanced case
+        # Balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [
-            (y_true, y_true),  # all correct
-            (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+            (y_true, y_true),  # All correct
+            (y_true, (y_true + 1) % n_classes),  # All false
+            (y_true, np.zeros_like(y_true)),  # All zero: Only first class correct
         ]
 
-        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        # Imbalanced case: Each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_and_predictions += [
-            (y_true, y_true),  # all correct
-            (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+            (y_true, y_true),  # All correct
+            (y_true, (y_true + 1) % n_classes),  # All false
+            (y_true, np.zeros_like(y_true)),  # All zero: Only first class correct
         ]
 
         for y_true, y_pred in labels_and_predictions:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             actual_f1 = evaluation_metrics.f1_score(confusion_matrix)
-            # we expect f1 to be identical to fbeta with beta = 1
+            # We expect f1 to be identical to fbeta with beta = 1.
             expected_f1_manual = evaluation_metrics.fbeta_score(
                 confusion_matrix, beta=1
             )
@@ -607,7 +615,8 @@ class TestEvaluationMetrics:
 
     def test_cohen_kappa_score(self, n_classes: int) -> None:
         """
-        Test the cohen kappa score metric for a variable number of classes in both balanced and unbalanced cases.
+        Test the Cohen's kappa score metric for a variable number of classes in both balanced and imbalanced cases.
+
         Comparing both to a manual expected value and the sklearn equivalent.
 
         Parameters
@@ -615,20 +624,20 @@ class TestEvaluationMetrics:
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # balanced case
+        # Balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [
-            (y_true, y_true),  # all correct
-            (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+            (y_true, y_true),  # All correct
+            (y_true, (y_true + 1) % n_classes),  # All false
+            (y_true, np.zeros_like(y_true)),  # All zero: Only first class correct
         ]
 
-        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        # Imbalanced case: Each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_and_predictions += [
-            (y_true, y_true),  # all correct
-            (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+            (y_true, y_true),  # All correct
+            (y_true, (y_true + 1) % n_classes),  # All false
+            (y_true, np.zeros_like(y_true)),  # All zero: Only first class correct
         ]
 
         for y_true, y_pred in labels_and_predictions:
@@ -639,28 +648,29 @@ class TestEvaluationMetrics:
 
     def test_matthews_corrcoef(self, n_classes: int) -> None:
         """
-        Test the matthews corrcoef score metric for a variable number of classes in both balanced and unbalanced cases.
-        Comparing both to a manual expected value and the sklearn equivalent.
+        Test the ``matthews_corrcoef`` metric for a variable number of classes in both balanced and imbalanced cases.
+
+        Comparing both to a manual expected value and the ``sklearn`` equivalent.
 
         Parameters
         ----------
         n_classes : int
             The number of classes in the dataset generated for testing the metric.
         """
-        # balanced case
+        # Balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [
-            (y_true, y_true),  # all correct
-            (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+            (y_true, y_true),  # All correct
+            (y_true, (y_true + 1) % n_classes),  # All false
+            (y_true, np.zeros_like(y_true)),  # All zero: Only first class correct
         ]
 
-        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        # Imbalanced case: Each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_and_predictions += [
-            (y_true, y_true),  # all correct
-            (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+            (y_true, y_true),  # All correct
+            (y_true, (y_true + 1) % n_classes),  # All false
+            (y_true, np.zeros_like(y_true)),  # All zero: Only first class correct
         ]
 
         for y_true, y_pred in labels_and_predictions:

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -309,10 +309,48 @@ class TestEvaluationMetrics:
             expected_f1 = evaluation_metrics.fbeta_score(confusion_matrix, beta=1)
             np.testing.assert_array_equal(actual_f1, expected_f1, strict=True)
 
-    @pytest.mark.skip("Test not yet implemented.")
-    def test_cohen_kappa_score(self):
-        pass  # TODO: implement this test
+    def test_cohen_kappa_score(self, n_classes=10):
+        # balanced case
+        y_true = np.arange(n_classes).repeat(5)
+        labels_and_predictions = [
+            (y_true, y_true),  # all correct
+            (y_true, (y_true + 1) % n_classes),  # all false
+            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+        ]
 
-    @pytest.mark.skip("Test not yet implemented.")
-    def test_matthews_corrcoef(self):
-        pass  # TODO: implement this test
+        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
+        labels_and_predictions += [
+            (y_true, y_true),  # all correct
+            (y_true, (y_true + 1) % n_classes),  # all false
+            (y_true, np.zeros_like(y_true))  # all zero: only first class correct
+        ]
+
+        for y_true, y_pred in labels_and_predictions:
+            confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
+            actual_kappa = evaluation_metrics.cohen_kappa_score(confusion_matrix)
+            expected_kappa = sklearn.metrics.cohen_kappa_score(y_true, y_pred)
+            assert actual_kappa == pytest.approx(expected_kappa, 1e-6)
+
+    def test_matthews_corrcoef(self, n_classes=10):
+        # balanced case
+        y_true = np.arange(n_classes).repeat(5)
+        labels_and_predictions = [
+            (y_true, y_true),  # all correct
+            (y_true, (y_true + 1) % n_classes),  # all false
+            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+        ]
+
+        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
+        labels_and_predictions += [
+            (y_true, y_true),  # all correct
+            (y_true, (y_true + 1) % n_classes),  # all false
+            (y_true, np.zeros_like(y_true))  # all zero: only first class correct
+        ]
+
+        for y_true, y_pred in labels_and_predictions:
+            confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
+            actual_kappa = evaluation_metrics.matthews_corrcoef(confusion_matrix)
+            expected_kappa = sklearn.metrics.matthews_corrcoef(y_true, y_pred)
+            assert actual_kappa == pytest.approx(expected_kappa, 1e-6)

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import sklearn.metrics
 
 from specialcouscous import evaluation_metrics
@@ -65,6 +66,21 @@ class TestEvaluationMetrics:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             assert evaluation_metrics.balanced_accuracy_score(confusion_matrix) == expected_accuracy
 
+    @pytest.mark.skip("Test not yet implemented.")
+    def test_precision_recall_fscore__no_average(self):
+        pass  # TODO: implement this test
+
+    @pytest.mark.skip("Test not yet implemented.")
+    def test_precision_recall_fscore__micro_average(self):
+        pass  # TODO: implement this test
+
+    @pytest.mark.skip("Test not yet implemented.")
+    def test_precision_recall_fscore__macro_average(self):
+        pass  # TODO: implement this test
+
+    @pytest.mark.skip("Test not yet implemented.")
+    def test_precision_recall_fscore__weighted_average(self):
+        pass  # TODO: implement this test
 
     def test_precision_score(self, n_classes=10):
         # balanced case
@@ -113,6 +129,13 @@ class TestEvaluationMetrics:
             actual_recall = evaluation_metrics.recall_score(confusion_matrix)
             np.testing.assert_array_equal(actual_recall, expected_recall, strict=True)
 
+    @pytest.mark.skip("Test not yet implemented.")
+    def test___f_score_from_precision_and_recall(self):
+        # scalar inputs
+
+        # array inputs
+        pass  # TODO: implement this test
+
     def test_fbeta_score(self, n_classes=10, beta=2):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
@@ -144,3 +167,15 @@ class TestEvaluationMetrics:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             actual_fbeta = evaluation_metrics.fbeta_score(confusion_matrix, beta=beta)
             np.testing.assert_array_equal(actual_fbeta, expected_fbeta, strict=True)
+
+    @pytest.mark.skip("Test not yet implemented.")
+    def test_f1_score(self):
+        pass  # TODO: implement this test
+
+    @pytest.mark.skip("Test not yet implemented.")
+    def test_cohen_kappa_score(self):
+        pass  # TODO: implement this test
+
+    @pytest.mark.skip("Test not yet implemented.")
+    def test_matthews_corrcoef(self):
+        pass  # TODO: implement this test

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -7,6 +7,11 @@ from specialcouscous import evaluation_metrics
 
 @pytest.mark.parametrize("n_classes", [2, 10, 100])
 class TestEvaluationMetrics:
+    """
+    Test class to test all multi-class evaluation metrics defined in evaluation_metrics.py for different numbers of
+    classes (at least two).
+    """
+
     @staticmethod
     def first_and_fill_rest(first: float, fill: float, total_length: int) -> np.ndarray[float]:
         """
@@ -29,7 +34,16 @@ class TestEvaluationMetrics:
         """
         return np.concat([np.array([first]), np.full(total_length - 1, fill)])
 
-    def test_accuracy_score(self, n_classes):
+    def test_accuracy_score(self, n_classes: int) -> None:
+        """
+        Test the accuracy score metric for a variable number of classes in both balanced and unbalanced cases. Comparing
+        both to a manual expected value and the sklearn equivalent.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -51,7 +65,16 @@ class TestEvaluationMetrics:
             assert actual_accuracy == expected_accuracy_manual
             assert actual_accuracy == expected_accuracy_sklearn
 
-    def test_balanced_accuracy_score(self, n_classes):
+    def test_balanced_accuracy_score(self, n_classes: int) -> None:
+        """
+        Test the balanced accuracy score metric for a variable number of classes in both balanced and unbalanced cases.
+        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -73,7 +96,17 @@ class TestEvaluationMetrics:
             assert actual_accuracy == expected_accuracy_manual
             assert actual_accuracy == expected_accuracy_sklearn
 
-    def test_precision_recall_fscore__totally_balanced(self, n_classes):
+    def test_precision_recall_fscore__totally_balanced(self, n_classes: int) -> None:
+        """
+        Test the precision_recall_fscore metric in the 100% balanced case: all classes have equal share of the labels
+        and equal class wise accuracy.
+        Comparing both to a manual expected value and the sklearn (near-)equivalent precision_recall_fscore_support.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # 100% balanced case: all classes have equal share of the labels and equal class wise accuracy
         classes = np.arange(n_classes)
         y_true = np.tile(classes, 5)  # each class appears 5 times
@@ -99,7 +132,17 @@ class TestEvaluationMetrics:
                 assert actual_score == pytest.approx(expected_class_wise_accuracy, 1e-6)
                 assert actual_score == pytest.approx(expected_score_sklearn, 1e-6)
 
-    def test_precision_recall_fscore__balanced_labels_imbalanced_predictions(self, n_classes):
+    def test_precision_recall_fscore__balanced_labels_imbalanced_predictions(self, n_classes: int) -> None:
+        """
+        Test the precision_recall_fscore metric in the case where the class labels are balanced but the classes have
+        different class-wise accuracies.
+        Comparing both to a manual expected value and the sklearn (near-)equivalent precision_recall_fscore_support.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # balanced labels but imbalanced accuracy: class labels are balanced but different class-wise accuracies
         y_true = np.arange(n_classes).repeat(n_classes)  # each class appears n_classes times, consecutively
         # Class i is predicted correctly (n_classes - i) times (i.e. the larger i, the lower the recall,
@@ -157,7 +200,17 @@ class TestEvaluationMetrics:
                 assert actual == pytest.approx(expected_manual, 1e-6)
                 assert actual == pytest.approx(expected_sklearn, 1e-6)
 
-    def test_precision_recall_fscore__imbalanced(self, n_classes):
+    def test_precision_recall_fscore__imbalanced(self, n_classes: int) -> None:
+        """
+        Test the precision_recall_fscore metric in the imbalanced case where both class labels and class accuracies are
+        imbalanced.
+        Comparing both to a manual expected value and the sklearn (near-)equivalent precision_recall_fscore_support.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # completely imbalanced: both class labels and class accuracies are imbalanced
         # class i appears (i + 1) * 2 times, consecutively
         y_true = np.concat([np.full((i + 1) * 2, i) for i in range(n_classes)])
@@ -227,7 +280,16 @@ class TestEvaluationMetrics:
             assert actual == pytest.approx(expected_manual, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
-    def test_precision_score(self, n_classes):
+    def test_precision_score(self, n_classes: int) -> None:
+        """
+        Test the precision score metric for a variable number of classes in both balanced and unbalanced cases.
+        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -256,7 +318,16 @@ class TestEvaluationMetrics:
             np.testing.assert_array_equal(actual_precision, expected_precision_manual, strict=True)
             np.testing.assert_array_equal(actual_precision, expected_precision_sklearn, strict=True)
 
-    def test_recall_score(self, n_classes):
+    def test_recall_score(self, n_classes: int) -> None:
+        """
+        Test the recall score metric for a variable number of classes in both balanced and unbalanced cases.
+        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -281,7 +352,19 @@ class TestEvaluationMetrics:
             np.testing.assert_array_equal(actual_recall, expected_recall_sklearn, strict=True)
 
     @pytest.mark.parametrize("beta", [0.5, 1, 10, 100])
-    def test_fbeta_score(self, n_classes, beta):
+    def test_fbeta_score(self, n_classes: int, beta: float) -> None:
+        """
+        Test the balanced accuracy score metric for a variable number of classes and betas in both balanced and
+        unbalanced cases.
+        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        beta : float
+            The beta parameter of the F-beta score.
+        """
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_prediction_and_expected_accuracy = [
@@ -317,7 +400,16 @@ class TestEvaluationMetrics:
             np.testing.assert_allclose(actual_fbeta, expected_fbeta_manual, atol=1e-6, strict=True)
             np.testing.assert_allclose(actual_fbeta, expected_fbeta_sklearn, atol=1e-6, strict=True)
 
-    def test_f1_score(self, n_classes):
+    def test_f1_score(self, n_classes: int) -> None:
+        """
+        Test the F1 score metric for a variable number of classes in both balanced and unbalanced cases.
+        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [
@@ -343,7 +435,16 @@ class TestEvaluationMetrics:
             np.testing.assert_array_equal(actual_f1, expected_f1_manual, strict=True)
             np.testing.assert_array_equal(actual_f1, expected_f1_sklearn, strict=True)
 
-    def test_cohen_kappa_score(self, n_classes):
+    def test_cohen_kappa_score(self, n_classes: int) -> None:
+        """
+        Test the cohen kappa score metric for a variable number of classes in both balanced and unbalanced cases.
+        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [
@@ -366,7 +467,16 @@ class TestEvaluationMetrics:
             expected_kappa = sklearn.metrics.cohen_kappa_score(y_true, y_pred)
             assert actual_kappa == pytest.approx(expected_kappa, 1e-6)
 
-    def test_matthews_corrcoef(self, n_classes):
+    def test_matthews_corrcoef(self, n_classes: int) -> None:
+        """
+        Test the matthews corrcoef score metric for a variable number of classes in both balanced and unbalanced cases.
+        Comparing both to a manual expected value and the sklearn equivalent.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
         labels_and_predictions = [

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -11,7 +11,7 @@ class TestEvaluationMetrics:
         labels_prediction_and_expected_accuracy = [
             (y_true, y_true, 1),  # all correct
             (y_true, (y_true + 1) % n_classes, 0),  # all false
-            (y_true, np.zeros_like(y_true), 0.1),  # all zero = only first correct
+            (y_true, np.zeros_like(y_true), 1 / n_classes),  # all zero = only first correct
         ]
         # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
@@ -30,14 +30,14 @@ class TestEvaluationMetrics:
         labels_prediction_and_expected_accuracy = [
             (y_true, y_true, 1),  # all correct
             (y_true, (y_true + 1) % n_classes, 0),  # all false
-            (y_true, np.zeros_like(y_true), 0.1),  # all zero = only first correct
+            (y_true, np.zeros_like(y_true), 1 / n_classes),  # all zero = only first correct
         ]
         # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_prediction_and_expected_accuracy += [
             (y_true, y_true, 1),  # all correct
             (y_true, (y_true + 1) % n_classes, 0),  # all false
-            (y_true, np.zeros_like(y_true), 0.1),  # all zero = only first correct
+            (y_true, np.zeros_like(y_true), 1 / n_classes),  # all zero = only first correct
         ]
         for y_true, y_pred, expected_accuracy in labels_prediction_and_expected_accuracy:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -380,6 +380,22 @@ class TestEvaluationMetrics:
             assert actual == pytest.approx(expected_manual, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
+    def test_precision_recall_fscore__invalid_average(self, n_classes: int) -> None:
+        """
+        Test precision_recall_fscore with invalid average parameters. Should raise a ValueError.
+
+        Parameters
+        ----------
+        n_classes : int
+            The number of classes in the dataset generated for testing the metric.
+        """
+        y_true = np.arange(n_classes).repeat(5)
+        confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_true)
+        invalid_averages = ["invalid_average", 1, True, 0.01234]
+        for invalid_average in invalid_averages:
+            with pytest.raises(ValueError):
+                evaluation_metrics.precision_recall_fscore(confusion_matrix, average=invalid_average)
+
     def test_precision_score(self, n_classes: int) -> None:
         """
         Test the precision score metric for a variable number of classes in both balanced and unbalanced cases.

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -168,9 +168,29 @@ class TestEvaluationMetrics:
             actual_fbeta = evaluation_metrics.fbeta_score(confusion_matrix, beta=beta)
             np.testing.assert_array_equal(actual_fbeta, expected_fbeta, strict=True)
 
-    @pytest.mark.skip("Test not yet implemented.")
-    def test_f1_score(self):
-        pass  # TODO: implement this test
+    def test_f1_score(self, n_classes=10):
+        # balanced case
+        y_true = np.arange(n_classes).repeat(5)
+        labels_and_predictions = [
+            (y_true, y_true),  # all correct
+            (y_true, (y_true + 1) % n_classes),  # all false
+            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
+        ]
+
+        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
+        labels_and_predictions += [
+            (y_true, y_true),  # all correct
+            (y_true, (y_true + 1) % n_classes),  # all false
+            (y_true, np.zeros_like(y_true))  # all zero: only first class correct
+        ]
+
+        for y_true, y_pred in labels_and_predictions:
+            confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
+            actual_f1 = evaluation_metrics.f1_score(confusion_matrix)
+            # we expect f1 to be identical to fbeta with beta = 1
+            expected_f1 = evaluation_metrics.fbeta_score(confusion_matrix, beta=1)
+            np.testing.assert_array_equal(actual_f1, expected_f1, strict=True)
 
     @pytest.mark.skip("Test not yet implemented.")
     def test_cohen_kappa_score(self):

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -394,7 +394,9 @@ class TestEvaluationMetrics:
         invalid_averages = ["invalid_average", 1, True, 0.01234]
         for invalid_average in invalid_averages:
             with pytest.raises(ValueError):
-                evaluation_metrics.precision_recall_fscore(confusion_matrix, average=invalid_average)
+                evaluation_metrics.precision_recall_fscore(
+                    confusion_matrix, average=invalid_average
+                )
 
     def test_precision_score(self, n_classes: int) -> None:
         """

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -5,7 +5,7 @@ import sklearn.metrics
 from specialcouscous import evaluation_metrics
 
 
-@pytest.mark.parametrize('n_classes', [2, 10, 100])
+@pytest.mark.parametrize("n_classes", [2, 10, 100])
 class TestEvaluationMetrics:
     @staticmethod
     def first_and_fill_rest(first: float, fill: float, total_length: int) -> np.ndarray[float]:
@@ -122,7 +122,10 @@ class TestEvaluationMetrics:
         denominator = expected_class_wise_precision + expected_class_wise_recall
         expected_class_wise_f1 = 2 * nominator / denominator
         expected_class_wise_precision_recall_f1 = [
-            expected_class_wise_precision, expected_class_wise_recall, expected_class_wise_f1]
+            expected_class_wise_precision,
+            expected_class_wise_recall,
+            expected_class_wise_f1,
+        ]
 
         confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
 
@@ -130,7 +133,8 @@ class TestEvaluationMetrics:
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix)
         expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred)
         for actual, expected_manual, expected_sklearn in zip(
-                actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn):
+            actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+        ):
             np.testing.assert_allclose(actual, expected_manual, atol=1e-6, strict=True)
             np.testing.assert_allclose(actual, expected_sklearn, atol=1e-6, strict=True)
 
@@ -147,7 +151,8 @@ class TestEvaluationMetrics:
             actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix, average=average)
             expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average=average)
             for actual, expected_class_wise, expected_sklearn in zip(
-                    actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn):
+                actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+            ):
                 expected_manual = expected_class_wise.mean()
                 assert actual == pytest.approx(expected_manual, 1e-6)
                 assert actual == pytest.approx(expected_sklearn, 1e-6)
@@ -163,8 +168,9 @@ class TestEvaluationMetrics:
         # -> precision (i + 1) / (2i + 1) for i > 0 and 1 / (n + 1) for i = 0)
         # To achieve this, the first half of occurrences for each class are predicted correctly while for the second
         # half, the next class is predicted
-        y_pred = np.concat([x for i in range(n_classes)
-                            for x in [np.full((i + 1), i), np.full((i + 1), (i + 1) % n_classes)]])
+        y_pred = np.concat(
+            [x for i in range(n_classes) for x in [np.full((i + 1), i), np.full((i + 1), (i + 1) % n_classes)]]
+        )
 
         total_predictions = len(y_true)
         correct_predictions = (y_true == y_pred).sum()
@@ -177,7 +183,10 @@ class TestEvaluationMetrics:
         denominator = expected_class_wise_precision + expected_class_wise_recall
         expected_class_wise_f1 = 2 * nominator / denominator
         expected_class_wise_precision_recall_f1 = [
-            expected_class_wise_precision, expected_class_wise_recall, expected_class_wise_f1]
+            expected_class_wise_precision,
+            expected_class_wise_recall,
+            expected_class_wise_f1,
+        ]
 
         confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
 
@@ -185,7 +194,8 @@ class TestEvaluationMetrics:
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix)
         expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred)
         for actual, expected_manual, expected_sklearn in zip(
-                actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn):
+            actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+        ):
             np.testing.assert_allclose(actual, expected_manual, atol=1e-6, strict=True)
             np.testing.assert_allclose(actual, expected_sklearn, atol=1e-6, strict=True)
 
@@ -201,7 +211,8 @@ class TestEvaluationMetrics:
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix, average="macro")
         expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average="macro")
         for actual, expected_class_wise, expected_sklearn in zip(
-                actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn):
+            actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+        ):
             expected_manual = expected_class_wise.mean()
             assert actual == pytest.approx(expected_manual, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
@@ -210,7 +221,8 @@ class TestEvaluationMetrics:
         actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix, average="weighted")
         expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average="weighted")
         for actual, expected_class_wise, expected_sklearn in zip(
-                actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn):
+            actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+        ):
             expected_manual = (expected_class_wise * class_weights).sum() / class_weights.sum()
             assert actual == pytest.approx(expected_manual, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
@@ -239,7 +251,8 @@ class TestEvaluationMetrics:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             actual_precision = evaluation_metrics.precision_score(confusion_matrix)
             expected_precision_sklearn = sklearn.metrics.precision_score(
-                y_true, y_pred, average=None, zero_division=np.nan)
+                y_true, y_pred, average=None, zero_division=np.nan
+            )
             np.testing.assert_array_equal(actual_precision, expected_precision_manual, strict=True)
             np.testing.assert_array_equal(actual_precision, expected_precision_sklearn, strict=True)
 
@@ -250,7 +263,7 @@ class TestEvaluationMetrics:
             (y_true, y_true, np.ones(n_classes)),  # all correct
             (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
             # all zero: only first class correct
-            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1., 0., n_classes)),
+            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1.0, 0.0, n_classes)),
         ]
         # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
@@ -258,7 +271,7 @@ class TestEvaluationMetrics:
             (y_true, y_true, np.ones(n_classes)),  # all correct
             (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
             # all zero: only first class correct
-            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1., 0., n_classes)),
+            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1.0, 0.0, n_classes)),
         ]
         for y_true, y_pred, expected_recall_manual in labels_prediction_and_expected_accuracy:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
@@ -267,7 +280,7 @@ class TestEvaluationMetrics:
             np.testing.assert_array_equal(actual_recall, expected_recall_manual, strict=True)
             np.testing.assert_array_equal(actual_recall, expected_recall_sklearn, strict=True)
 
-    @pytest.mark.parametrize('beta', [0.5, 1, 10, 100])
+    @pytest.mark.parametrize("beta", [0.5, 1, 10, 100])
     def test_fbeta_score(self, n_classes, beta):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
@@ -298,8 +311,9 @@ class TestEvaluationMetrics:
         for y_true, y_pred, expected_fbeta_manual in labels_prediction_and_expected_accuracy:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             actual_fbeta = evaluation_metrics.fbeta_score(confusion_matrix, beta=beta)
-            expected_fbeta_sklearn = sklearn.metrics.fbeta_score(y_true, y_pred, beta=beta, average=None,
-                                                                 zero_division=np.nan)
+            expected_fbeta_sklearn = sklearn.metrics.fbeta_score(
+                y_true, y_pred, beta=beta, average=None, zero_division=np.nan
+            )
             np.testing.assert_allclose(actual_fbeta, expected_fbeta_manual, atol=1e-6, strict=True)
             np.testing.assert_allclose(actual_fbeta, expected_fbeta_sklearn, atol=1e-6, strict=True)
 
@@ -317,7 +331,7 @@ class TestEvaluationMetrics:
         labels_and_predictions += [
             (y_true, y_true),  # all correct
             (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true))  # all zero: only first class correct
+            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
         ]
 
         for y_true, y_pred in labels_and_predictions:
@@ -343,7 +357,7 @@ class TestEvaluationMetrics:
         labels_and_predictions += [
             (y_true, y_true),  # all correct
             (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true))  # all zero: only first class correct
+            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
         ]
 
         for y_true, y_pred in labels_and_predictions:
@@ -366,7 +380,7 @@ class TestEvaluationMetrics:
         labels_and_predictions += [
             (y_true, y_true),  # all correct
             (y_true, (y_true + 1) % n_classes),  # all false
-            (y_true, np.zeros_like(y_true))  # all zero: only first class correct
+            (y_true, np.zeros_like(y_true)),  # all zero: only first class correct
         ]
 
         for y_true, y_pred in labels_and_predictions:

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -5,6 +5,28 @@ from specialcouscous import evaluation_metrics
 
 
 class TestEvaluationMetrics:
+    @staticmethod
+    def first_and_fill_rest(first: float, fill: float, total_length: int) -> np.ndarray[float]:
+        """
+        Create a numpy array (1D) of length total_length where the first value is first and all remaining values are
+        filled with the specified fill value.
+
+        Parameters
+        ----------
+        first : float
+            The value to set the first array element to.
+        fill : float
+            The value to set all other array elements to.
+        total_length : int
+            The total length of the array (including the first value).
+
+        Returns
+        -------
+        np.ndarray[float]
+            The created array [first, fill, ... fill] of length total_length.
+        """
+        return np.concat([np.array([first]), np.full(total_length - 1, fill)])
+
     def test_accuracy_score(self, n_classes=10):
         # balanced case
         y_true = np.arange(n_classes).repeat(5)
@@ -43,3 +65,82 @@ class TestEvaluationMetrics:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             assert evaluation_metrics.balanced_accuracy_score(confusion_matrix) == expected_accuracy
 
+
+    def test_precision_score(self, n_classes=10):
+        # balanced case
+        y_true = np.arange(n_classes).repeat(5)
+        labels_prediction_and_expected_accuracy = [
+            (y_true, y_true, np.ones(n_classes)),  # all correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
+            # all zero: for first class: 5 correct predictions, but also 5 * (n_classes - 1) incorrect predictions
+            # -> 1 / n_classes, no prediction at all for all other classes -> nan
+            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1 / n_classes, np.nan, n_classes)),
+        ]
+        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
+        n_samples = 2 * n_classes
+        labels_prediction_and_expected_accuracy += [
+            (y_true, y_true, np.ones(n_classes)),  # all correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
+            # all zero: for first class: 5 * (1 + n_classes) correct predictions, but also n_classes - 1 incorrect
+            # predictions -> (1 + n_classes) / (2 * n_classes), no prediction at all for all other classes -> nan
+            (y_true, np.zeros_like(y_true), self.first_and_fill_rest((1 + n_classes) / n_samples, np.nan, n_classes)),
+        ]
+        for y_true, y_pred, expected_precision in labels_prediction_and_expected_accuracy:
+            confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
+            actual_precision = evaluation_metrics.precision_score(confusion_matrix)
+            np.testing.assert_array_equal(actual_precision, expected_precision, strict=True)
+
+    def test_recall_score(self, n_classes=10):
+        # balanced case
+        y_true = np.arange(n_classes).repeat(5)
+        labels_prediction_and_expected_accuracy = [
+            (y_true, y_true, np.ones(n_classes)),  # all correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
+            # all zero: only first class correct
+            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1., 0., n_classes)),
+        ]
+        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
+        labels_prediction_and_expected_accuracy += [
+            (y_true, y_true, np.ones(n_classes)),  # all correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
+            # all zero: only first class correct
+            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1., 0., n_classes)),
+        ]
+        for y_true, y_pred, expected_recall in labels_prediction_and_expected_accuracy:
+            confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
+            actual_recall = evaluation_metrics.recall_score(confusion_matrix)
+            np.testing.assert_array_equal(actual_recall, expected_recall, strict=True)
+
+    def test_fbeta_score(self, n_classes=10, beta=2):
+        # balanced case
+        y_true = np.arange(n_classes).repeat(5)
+        labels_prediction_and_expected_accuracy = [
+            (y_true, y_true, np.ones(n_classes)),  # all correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
+        ]
+        # all zero: only first class correct
+        precision = 1 / n_classes
+        recall = 1
+        f_beta = (1 + beta**2) * (precision * recall) / (beta**2 * precision + recall)
+        expected = self.first_and_fill_rest(f_beta, np.nan, n_classes)
+        labels_prediction_and_expected_accuracy += [(y_true, np.zeros_like(y_true), expected)]
+
+        # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
+        y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
+        labels_prediction_and_expected_accuracy += [
+            (y_true, y_true, np.ones(n_classes)),  # all correct
+            (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
+        ]
+        # all zero: only first class correct
+        precision = (1 + n_classes) / (2 * n_classes)
+        recall = 1
+        f_beta = (1 + beta**2) * (precision * recall) / (beta**2 * precision + recall)
+        expected = self.first_and_fill_rest(f_beta, np.nan, n_classes)
+        labels_prediction_and_expected_accuracy += [(y_true, np.zeros_like(y_true), expected)]
+
+        for y_true, y_pred, expected_fbeta in labels_prediction_and_expected_accuracy:
+            confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
+            actual_fbeta = evaluation_metrics.fbeta_score(confusion_matrix, beta=beta)
+            np.testing.assert_array_equal(actual_fbeta, expected_fbeta, strict=True)

--- a/tests/test_evaluation_metrics.py
+++ b/tests/test_evaluation_metrics.py
@@ -13,7 +13,9 @@ class TestEvaluationMetrics:
     """
 
     @staticmethod
-    def first_and_fill_rest(first: float, fill: float, total_length: int) -> np.ndarray[float]:
+    def first_and_fill_rest(
+        first: float, fill: float, total_length: int
+    ) -> np.ndarray[float]:
         """
         Create a numpy array (1D) of length total_length where the first value is first and all remaining values are
         filled with the specified fill value.
@@ -49,16 +51,28 @@ class TestEvaluationMetrics:
         labels_prediction_and_expected_accuracy = [
             (y_true, y_true, 1),  # all correct
             (y_true, (y_true + 1) % n_classes, 0),  # all false
-            (y_true, np.zeros_like(y_true), 1 / n_classes),  # all zero = only first correct
+            (
+                y_true,
+                np.zeros_like(y_true),
+                1 / n_classes,
+            ),  # all zero = only first correct
         ]
         # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_prediction_and_expected_accuracy += [
             (y_true, y_true, 1),  # all correct
             (y_true, (y_true + 1) % n_classes, 0),  # all false
-            (y_true, np.zeros_like(y_true), (1 + n_classes) / (2 * n_classes)),  # all zero = only first correct
+            (
+                y_true,
+                np.zeros_like(y_true),
+                (1 + n_classes) / (2 * n_classes),
+            ),  # all zero = only first correct
         ]
-        for y_true, y_pred, expected_accuracy_manual in labels_prediction_and_expected_accuracy:
+        for (
+            y_true,
+            y_pred,
+            expected_accuracy_manual,
+        ) in labels_prediction_and_expected_accuracy:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             expected_accuracy_sklearn = sklearn.metrics.accuracy_score(y_true, y_pred)
             actual_accuracy = evaluation_metrics.accuracy_score(confusion_matrix)
@@ -80,19 +94,35 @@ class TestEvaluationMetrics:
         labels_prediction_and_expected_accuracy = [
             (y_true, y_true, 1),  # all correct
             (y_true, (y_true + 1) % n_classes, 0),  # all false
-            (y_true, np.zeros_like(y_true), 1 / n_classes),  # all zero = only first correct
+            (
+                y_true,
+                np.zeros_like(y_true),
+                1 / n_classes,
+            ),  # all zero = only first correct
         ]
         # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
         labels_prediction_and_expected_accuracy += [
             (y_true, y_true, 1),  # all correct
             (y_true, (y_true + 1) % n_classes, 0),  # all false
-            (y_true, np.zeros_like(y_true), 1 / n_classes),  # all zero = only first correct
+            (
+                y_true,
+                np.zeros_like(y_true),
+                1 / n_classes,
+            ),  # all zero = only first correct
         ]
-        for y_true, y_pred, expected_accuracy_manual in labels_prediction_and_expected_accuracy:
+        for (
+            y_true,
+            y_pred,
+            expected_accuracy_manual,
+        ) in labels_prediction_and_expected_accuracy:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
-            expected_accuracy_sklearn = sklearn.metrics.balanced_accuracy_score(y_true, y_pred)
-            actual_accuracy = evaluation_metrics.balanced_accuracy_score(confusion_matrix)
+            expected_accuracy_sklearn = sklearn.metrics.balanced_accuracy_score(
+                y_true, y_pred
+            )
+            actual_accuracy = evaluation_metrics.balanced_accuracy_score(
+                confusion_matrix
+            )
             assert actual_accuracy == expected_accuracy_manual
             assert actual_accuracy == expected_accuracy_sklearn
 
@@ -114,25 +144,41 @@ class TestEvaluationMetrics:
         y_pred = np.concat([np.tile(classes, 3), (np.tile(classes, 2) + 1) % n_classes])
 
         expected_class_wise_accuracy = 0.6
-        expected_class_wise_accuracy_array = np.full(n_classes, expected_class_wise_accuracy)
+        expected_class_wise_accuracy_array = np.full(
+            n_classes, expected_class_wise_accuracy
+        )
         confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
 
         # no average = class-wise scores, all scores are identical because everything is balanced
         actual = evaluation_metrics.precision_recall_fscore(confusion_matrix)
-        expected_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred)
+        expected_sklearn = sklearn.metrics.precision_recall_fscore_support(
+            y_true, y_pred
+        )
         for actual_score_array, expected_sklearn_array in zip(actual, expected_sklearn):
-            np.testing.assert_array_equal(actual_score_array, expected_class_wise_accuracy_array, strict=True)
-            np.testing.assert_array_equal(actual_score_array, expected_sklearn_array, strict=True)
+            np.testing.assert_array_equal(
+                actual_score_array, expected_class_wise_accuracy_array, strict=True
+            )
+            np.testing.assert_array_equal(
+                actual_score_array, expected_sklearn_array, strict=True
+            )
 
         # all averages are identical because everything is balanced
         for average in ["micro", "macro", "weighted"]:
-            actual_scores = evaluation_metrics.precision_recall_fscore(confusion_matrix, average=average)
-            expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average=average)
-            for actual_score, expected_score_sklearn in zip(actual_scores, expected_scores_sklearn):
+            actual_scores = evaluation_metrics.precision_recall_fscore(
+                confusion_matrix, average=average
+            )
+            expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(
+                y_true, y_pred, average=average
+            )
+            for actual_score, expected_score_sklearn in zip(
+                actual_scores, expected_scores_sklearn
+            ):
                 assert actual_score == pytest.approx(expected_class_wise_accuracy, 1e-6)
                 assert actual_score == pytest.approx(expected_score_sklearn, 1e-6)
 
-    def test_precision_recall_fscore__balanced_labels_imbalanced_predictions(self, n_classes: int) -> None:
+    def test_precision_recall_fscore__balanced_labels_imbalanced_predictions(
+        self, n_classes: int
+    ) -> None:
         """
         Test the precision_recall_fscore metric in the case where the class labels are balanced but the classes have
         different class-wise accuracies.
@@ -144,7 +190,9 @@ class TestEvaluationMetrics:
             The number of classes in the dataset generated for testing the metric.
         """
         # balanced labels but imbalanced accuracy: class labels are balanced but different class-wise accuracies
-        y_true = np.arange(n_classes).repeat(n_classes)  # each class appears n_classes times, consecutively
+        y_true = np.arange(n_classes).repeat(
+            n_classes
+        )  # each class appears n_classes times, consecutively
         # Class i is predicted correctly (n_classes - i) times (i.e. the larger i, the lower the recall,
         # class 0 has recall 1). All incorrect predictions predict class 0 instead. (i.e. class 0 has low precision,
         # all other classes have precision 1)
@@ -158,7 +206,9 @@ class TestEvaluationMetrics:
         correct_predictions = total_predictions - incorrect_predictions
         precision_class_zero = n_classes / (n_classes + incorrect_predictions)
 
-        expected_class_wise_precision = self.first_and_fill_rest(precision_class_zero, 1, n_classes)
+        expected_class_wise_precision = self.first_and_fill_rest(
+            precision_class_zero, 1, n_classes
+        )
         expected_class_wise_recall = (n_classes - np.arange(n_classes)) / n_classes
 
         nominator = expected_class_wise_precision * expected_class_wise_recall
@@ -173,28 +223,46 @@ class TestEvaluationMetrics:
         confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
 
         # no average = class-wise scores, all scores are identical because everything is balanced
-        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix)
-        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred)
+        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
+            confusion_matrix
+        )
+        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(
+            y_true, y_pred
+        )
         for actual, expected_manual, expected_sklearn in zip(
-            actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+            actual_precision_recall_f1,
+            expected_class_wise_precision_recall_f1,
+            expected_scores_sklearn,
         ):
             np.testing.assert_allclose(actual, expected_manual, atol=1e-6, strict=True)
             np.testing.assert_allclose(actual, expected_sklearn, atol=1e-6, strict=True)
 
         # micro average of recall, precision, and f1 are all identical to the overall accuracy
         expected_overall_accuracy = correct_predictions / total_predictions
-        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix, average="micro")
-        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average="micro")
-        for actual, expected_sklearn in zip(actual_precision_recall_f1, expected_scores_sklearn):
+        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
+            confusion_matrix, average="micro"
+        )
+        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(
+            y_true, y_pred, average="micro"
+        )
+        for actual, expected_sklearn in zip(
+            actual_precision_recall_f1, expected_scores_sklearn
+        ):
             assert actual == pytest.approx(expected_overall_accuracy, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
         # macro average: mean of class-wise scores, weighted average identical since true class distribution is balanced
         for average in ["macro", "weighted"]:
-            actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix, average=average)
-            expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average=average)
+            actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
+                confusion_matrix, average=average
+            )
+            expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(
+                y_true, y_pred, average=average
+            )
             for actual, expected_class_wise, expected_sklearn in zip(
-                actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+                actual_precision_recall_f1,
+                expected_class_wise_precision_recall_f1,
+                expected_scores_sklearn,
             ):
                 expected_manual = expected_class_wise.mean()
                 assert actual == pytest.approx(expected_manual, 1e-6)
@@ -222,7 +290,11 @@ class TestEvaluationMetrics:
         # To achieve this, the first half of occurrences for each class are predicted correctly while for the second
         # half, the next class is predicted
         y_pred = np.concat(
-            [x for i in range(n_classes) for x in [np.full((i + 1), i), np.full((i + 1), (i + 1) % n_classes)]]
+            [
+                x
+                for i in range(n_classes)
+                for x in [np.full((i + 1), i), np.full((i + 1), (i + 1) % n_classes)]
+            ]
         )
 
         total_predictions = len(y_true)
@@ -230,7 +302,9 @@ class TestEvaluationMetrics:
 
         classes = np.arange(n_classes)
         class_weights = (classes + 1) * 2
-        expected_class_wise_precision = (classes + 1) / (classes + 2 + (classes - 1) % n_classes)
+        expected_class_wise_precision = (classes + 1) / (
+            classes + 2 + (classes - 1) % n_classes
+        )
         expected_class_wise_recall = np.full(n_classes, 0.5)
         nominator = expected_class_wise_precision * expected_class_wise_recall
         denominator = expected_class_wise_precision + expected_class_wise_recall
@@ -244,39 +318,65 @@ class TestEvaluationMetrics:
         confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
 
         # no average = class-wise scores, all scores are identical because everything is balanced
-        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix)
-        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred)
+        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
+            confusion_matrix
+        )
+        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(
+            y_true, y_pred
+        )
         for actual, expected_manual, expected_sklearn in zip(
-            actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+            actual_precision_recall_f1,
+            expected_class_wise_precision_recall_f1,
+            expected_scores_sklearn,
         ):
             np.testing.assert_allclose(actual, expected_manual, atol=1e-6, strict=True)
             np.testing.assert_allclose(actual, expected_sklearn, atol=1e-6, strict=True)
 
         # micro average of recall, precision, and f1 are all identical to the overall accuracy
         expected_overall_accuracy = correct_predictions / total_predictions
-        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix, average="micro")
-        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average="micro")
-        for actual, expected_sklearn in zip(actual_precision_recall_f1, expected_scores_sklearn):
+        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
+            confusion_matrix, average="micro"
+        )
+        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(
+            y_true, y_pred, average="micro"
+        )
+        for actual, expected_sklearn in zip(
+            actual_precision_recall_f1, expected_scores_sklearn
+        ):
             assert actual == pytest.approx(expected_overall_accuracy, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
         # macro average: mean of class-wise scores
-        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix, average="macro")
-        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average="macro")
+        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
+            confusion_matrix, average="macro"
+        )
+        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(
+            y_true, y_pred, average="macro"
+        )
         for actual, expected_class_wise, expected_sklearn in zip(
-            actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+            actual_precision_recall_f1,
+            expected_class_wise_precision_recall_f1,
+            expected_scores_sklearn,
         ):
             expected_manual = expected_class_wise.mean()
             assert actual == pytest.approx(expected_manual, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
         # weighted average: mean of class-wise scores
-        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(confusion_matrix, average="weighted")
-        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(y_true, y_pred, average="weighted")
+        actual_precision_recall_f1 = evaluation_metrics.precision_recall_fscore(
+            confusion_matrix, average="weighted"
+        )
+        expected_scores_sklearn = sklearn.metrics.precision_recall_fscore_support(
+            y_true, y_pred, average="weighted"
+        )
         for actual, expected_class_wise, expected_sklearn in zip(
-            actual_precision_recall_f1, expected_class_wise_precision_recall_f1, expected_scores_sklearn
+            actual_precision_recall_f1,
+            expected_class_wise_precision_recall_f1,
+            expected_scores_sklearn,
         ):
-            expected_manual = (expected_class_wise * class_weights).sum() / class_weights.sum()
+            expected_manual = (
+                expected_class_wise * class_weights
+            ).sum() / class_weights.sum()
             assert actual == pytest.approx(expected_manual, 1e-6)
             assert actual == pytest.approx(expected_sklearn, 1e-6)
 
@@ -297,7 +397,11 @@ class TestEvaluationMetrics:
             (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
             # all zero: for first class: 5 correct predictions, but also 5 * (n_classes - 1) incorrect predictions
             # -> 1 / n_classes, no prediction at all for all other classes -> nan
-            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1 / n_classes, np.nan, n_classes)),
+            (
+                y_true,
+                np.zeros_like(y_true),
+                self.first_and_fill_rest(1 / n_classes, np.nan, n_classes),
+            ),
         ]
         # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
@@ -307,16 +411,30 @@ class TestEvaluationMetrics:
             (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
             # all zero: for first class: 5 * (1 + n_classes) correct predictions, but also n_classes - 1 incorrect
             # predictions -> (1 + n_classes) / (2 * n_classes), no prediction at all for all other classes -> nan
-            (y_true, np.zeros_like(y_true), self.first_and_fill_rest((1 + n_classes) / n_samples, np.nan, n_classes)),
+            (
+                y_true,
+                np.zeros_like(y_true),
+                self.first_and_fill_rest(
+                    (1 + n_classes) / n_samples, np.nan, n_classes
+                ),
+            ),
         ]
-        for y_true, y_pred, expected_precision_manual in labels_prediction_and_expected_accuracy:
+        for (
+            y_true,
+            y_pred,
+            expected_precision_manual,
+        ) in labels_prediction_and_expected_accuracy:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             actual_precision = evaluation_metrics.precision_score(confusion_matrix)
             expected_precision_sklearn = sklearn.metrics.precision_score(
                 y_true, y_pred, average=None, zero_division=np.nan
             )
-            np.testing.assert_array_equal(actual_precision, expected_precision_manual, strict=True)
-            np.testing.assert_array_equal(actual_precision, expected_precision_sklearn, strict=True)
+            np.testing.assert_array_equal(
+                actual_precision, expected_precision_manual, strict=True
+            )
+            np.testing.assert_array_equal(
+                actual_precision, expected_precision_sklearn, strict=True
+            )
 
     def test_recall_score(self, n_classes: int) -> None:
         """
@@ -334,7 +452,11 @@ class TestEvaluationMetrics:
             (y_true, y_true, np.ones(n_classes)),  # all correct
             (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
             # all zero: only first class correct
-            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1.0, 0.0, n_classes)),
+            (
+                y_true,
+                np.zeros_like(y_true),
+                self.first_and_fill_rest(1.0, 0.0, n_classes),
+            ),
         ]
         # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
@@ -342,14 +464,28 @@ class TestEvaluationMetrics:
             (y_true, y_true, np.ones(n_classes)),  # all correct
             (y_true, (y_true + 1) % n_classes, np.zeros(n_classes)),  # all false
             # all zero: only first class correct
-            (y_true, np.zeros_like(y_true), self.first_and_fill_rest(1.0, 0.0, n_classes)),
+            (
+                y_true,
+                np.zeros_like(y_true),
+                self.first_and_fill_rest(1.0, 0.0, n_classes),
+            ),
         ]
-        for y_true, y_pred, expected_recall_manual in labels_prediction_and_expected_accuracy:
+        for (
+            y_true,
+            y_pred,
+            expected_recall_manual,
+        ) in labels_prediction_and_expected_accuracy:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             actual_recall = evaluation_metrics.recall_score(confusion_matrix)
-            expected_recall_sklearn = sklearn.metrics.recall_score(y_true, y_pred, average=None)
-            np.testing.assert_array_equal(actual_recall, expected_recall_manual, strict=True)
-            np.testing.assert_array_equal(actual_recall, expected_recall_sklearn, strict=True)
+            expected_recall_sklearn = sklearn.metrics.recall_score(
+                y_true, y_pred, average=None
+            )
+            np.testing.assert_array_equal(
+                actual_recall, expected_recall_manual, strict=True
+            )
+            np.testing.assert_array_equal(
+                actual_recall, expected_recall_sklearn, strict=True
+            )
 
     @pytest.mark.parametrize("beta", [0.5, 1, 10, 100])
     def test_fbeta_score(self, n_classes: int, beta: float) -> None:
@@ -376,7 +512,9 @@ class TestEvaluationMetrics:
         recall = 1
         f_beta = (1 + beta**2) * (precision * recall) / (beta**2 * precision + recall)
         expected = self.first_and_fill_rest(f_beta, 0, n_classes)
-        labels_prediction_and_expected_accuracy += [(y_true, np.zeros_like(y_true), expected)]
+        labels_prediction_and_expected_accuracy += [
+            (y_true, np.zeros_like(y_true), expected)
+        ]
 
         # imbalanced case: each class 5 times, except for first class: 5 * (1 + n_classes) times
         y_true = np.concat([np.arange(n_classes), np.zeros(n_classes)]).repeat(5)
@@ -389,16 +527,26 @@ class TestEvaluationMetrics:
         recall = 1
         f_beta = (1 + beta**2) * (precision * recall) / (beta**2 * precision + recall)
         expected = self.first_and_fill_rest(f_beta, 0, n_classes)
-        labels_prediction_and_expected_accuracy += [(y_true, np.zeros_like(y_true), expected)]
+        labels_prediction_and_expected_accuracy += [
+            (y_true, np.zeros_like(y_true), expected)
+        ]
 
-        for y_true, y_pred, expected_fbeta_manual in labels_prediction_and_expected_accuracy:
+        for (
+            y_true,
+            y_pred,
+            expected_fbeta_manual,
+        ) in labels_prediction_and_expected_accuracy:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             actual_fbeta = evaluation_metrics.fbeta_score(confusion_matrix, beta=beta)
             expected_fbeta_sklearn = sklearn.metrics.fbeta_score(
                 y_true, y_pred, beta=beta, average=None, zero_division=np.nan
             )
-            np.testing.assert_allclose(actual_fbeta, expected_fbeta_manual, atol=1e-6, strict=True)
-            np.testing.assert_allclose(actual_fbeta, expected_fbeta_sklearn, atol=1e-6, strict=True)
+            np.testing.assert_allclose(
+                actual_fbeta, expected_fbeta_manual, atol=1e-6, strict=True
+            )
+            np.testing.assert_allclose(
+                actual_fbeta, expected_fbeta_sklearn, atol=1e-6, strict=True
+            )
 
     def test_f1_score(self, n_classes: int) -> None:
         """
@@ -430,8 +578,12 @@ class TestEvaluationMetrics:
             confusion_matrix = sklearn.metrics.confusion_matrix(y_true, y_pred)
             actual_f1 = evaluation_metrics.f1_score(confusion_matrix)
             # we expect f1 to be identical to fbeta with beta = 1
-            expected_f1_manual = evaluation_metrics.fbeta_score(confusion_matrix, beta=1)
-            expected_f1_sklearn = sklearn.metrics.f1_score(y_true, y_pred, average=None, zero_division=np.nan)
+            expected_f1_manual = evaluation_metrics.fbeta_score(
+                confusion_matrix, beta=1
+            )
+            expected_f1_sklearn = sklearn.metrics.f1_score(
+                y_true, y_pred, average=None, zero_division=np.nan
+            )
             np.testing.assert_array_equal(actual_f1, expected_f1_manual, strict=True)
             np.testing.assert_array_equal(actual_f1, expected_f1_sklearn, strict=True)
 


### PR DESCRIPTION
Adds computation of evaluation metrics from confusion matrices. The following metrics are added, their interfaces are based on the corresponding `sklearn.metrics` functions:
- **Accuracy:** the global accuracy
- **Balanced Accuracy:** the accuracy as average over class-wise recalls
- **Precision, Recall, and Fβ-Score:** with the following averaging options (`average` parameter)
  - `None`: no averaging, return class-wise
  - `"micro"`: compute metrics globally → equal importance on each sample
  - `"macro"`: compute metrics class-wise, then average over classes → equal importance on each class, minority classes can outweigh majority classes
  - `"weighted"`: compute metrics class-wise, then average over classes weighted by their support (#true samples)
  - As we are focussing on multi-class classification, the average options `"binary"` and `"samples"` are not included.
- **Cohen's Kappa:** compare classification to random guessing, values from -1 to +1, the higher the better, robust to class imbalance but not originally intended for classification problems
- **Matthews Correlation Coefficient (MCC):** see https://en.wikipedia.org/wiki/Phi_coefficient, values from -1 to +1, the higher the better, robust to class imbalance

Solves Issue #16 