### PR TITLE
Feature: Enable node local parallelism

### DIFF
--- a/scripts/experiments/generate_breaking_iid_job_scripts.py
+++ b/scripts/experiments/generate_breaking_iid_job_scripts.py
@@ -80,7 +80,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_chunking_job_scripts.py
+++ b/scripts/experiments/generate_chunking_job_scripts.py
@@ -81,7 +81,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_parallel_acc_drop_job_scripts.py
+++ b/scripts/experiments/generate_parallel_acc_drop_job_scripts.py
@@ -63,7 +63,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_parallel_evaluation_from_breaking_iid_ckpt_job_scripts.py
+++ b/scripts/experiments/generate_parallel_evaluation_from_breaking_iid_ckpt_job_scripts.py
@@ -75,7 +75,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_parallel_evaluation_from_ckpt_job_scripts.py
+++ b/scripts/experiments/generate_parallel_evaluation_from_ckpt_job_scripts.py
@@ -92,7 +92,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_parallel_inference_comparison_job_scripts.py
+++ b/scripts/experiments/generate_parallel_inference_comparison_job_scripts.py
@@ -77,7 +77,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_parallel_strong_scaling_job_scripts.py
+++ b/scripts/experiments/generate_parallel_strong_scaling_job_scripts.py
@@ -85,7 +85,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_parallel_weak_scaling_job_scripts.py
+++ b/scripts/experiments/generate_parallel_weak_scaling_job_scripts.py
@@ -81,7 +81,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_scaling_job_scripts.py
+++ b/scripts/experiments/generate_scaling_job_scripts.py
@@ -102,7 +102,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_serial_acc_drop_job_scripts.py
+++ b/scripts/experiments/generate_serial_acc_drop_job_scripts.py
@@ -54,7 +54,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_serial_inference_comparison_job_scripts.py
+++ b/scripts/experiments/generate_serial_inference_comparison_job_scripts.py
@@ -53,7 +53,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_serial_strong_baseline_job_scripts.py
+++ b/scripts/experiments/generate_serial_strong_baseline_job_scripts.py
@@ -54,7 +54,7 @@ BASE_DIR=${{BASE_DIR:-/hkfs/work/workspace/scratch/ku4408-SpecialCouscous}}
 export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi/4.1
 source "${{BASE_DIR}}"/special-couscous-venv-openmpi4/bin/activate  # Activate venv.
 

--- a/scripts/experiments/generate_single_node_job_scripts.py
+++ b/scripts/experiments/generate_single_node_job_scripts.py
@@ -53,7 +53,7 @@ export OMP_NUM_THREADS=${{SLURM_CPUS_PER_TASK}}
 export PYDIR=${{BASE_DIR}}/special-couscous/specialcouscous
 
 ml purge              # Unload all currently loaded modules.
-ml load compiler/gnu  # Load required modules.
+ml load compiler/llvm  # Load required modules.
 ml load mpi/openmpi
 source "${{BASE_DIR}}"/special-couscous-venv/bin/activate  # Activate venv.
 


### PR DESCRIPTION
Enable `sklearn`s parallelism for the node-local sub-forests by adding a `node_local_jobs` parameter to `DistributedRandomForest` which defaults to `-1` (use all available CPUs).
Since the `compiler/gnu` module appears to be incompatible with `joblib` (the underlying parallelization used by `sklearn`), we switch to `llvm` for the experiments.